### PR TITLE
Stringly conversions moved to a separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,6 +543,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_str_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b6009251ec4a3826c297b8a7baade19d73a642a89759d107826ca9ac944cc4a"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "sha1"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,7 +607,7 @@ name = "stringly_conversions"
 version = "0.1.0"
 dependencies = [
  "paste",
- "serde_str_helpers",
+ "serde_str_helpers 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,6 +587,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
 
 [[package]]
+name = "stringly_conversions"
+version = "0.1.0"
+dependencies = [
+ "serde_str_helpers",
+]
+
+[[package]]
 name = "subtle"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14248cc8eced350e20122a291613de29e4fa129ba2731818c4cdbb44fccd3e55"
 
 [[package]]
+name = "paste"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0520af26d4cf99643dbbe093a61507922b57232d9978d8491fdc8f7b44573c8c"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,6 +596,7 @@ checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
 name = "stringly_conversions"
 version = "0.1.0"
 dependencies = [
+ "paste",
  "serde_str_helpers",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,5 @@ tor = ["torut/v3", "torut/v2", "ed25519-dalek", "parse_arg", "std"]
 async = ["async-trait", "std"]
 
 [workspace]
-members = ["derive", ".", "serde_str_helpers"]
+members = ["derive", ".", "serde_str_helpers", "stringly_conversions"]
 default-members = ["derive", "."]

--- a/stringly_conversions/Cargo.toml
+++ b/stringly_conversions/Cargo.toml
@@ -10,5 +10,5 @@ edition = "2018"
 alloc = []
 
 [dependencies]
-serde_str_helpers = { version = "0.1", path = "../serde_str_helpers", optional = true }
+serde_str_helpers = { version = "0.1", optional = true }
 paste = "1.0.1"

--- a/stringly_conversions/Cargo.toml
+++ b/stringly_conversions/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "stringly_conversions"
+version = "0.1.0"
+authors = ["Martin Habovstiak <martin.habovstiak@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+alloc = []
+
+[dependencies]
+serde_str_helpers = { version = "0.1", path = "../serde_str_helpers", optional = true }

--- a/stringly_conversions/Cargo.toml
+++ b/stringly_conversions/Cargo.toml
@@ -11,3 +11,4 @@ alloc = []
 
 [dependencies]
 serde_str_helpers = { version = "0.1", path = "../serde_str_helpers", optional = true }
+paste = "1.0.1"

--- a/stringly_conversions/README.md
+++ b/stringly_conversions/README.md
@@ -1,0 +1,10 @@
+# Stringly conversions
+
+A crate helping to convert to/from various representations of strings.
+
+## Features
+
+* `no_std` with an optional feature to enable `alloc`
+* Macros for implementing `TryFrom<Stringly> for YourType` where
+  `YourType: FromStr`.
+* Macros for implementing `From<YourType> for Stringly` using `Display`

--- a/stringly_conversions/src/lib.rs
+++ b/stringly_conversions/src/lib.rs
@@ -29,9 +29,9 @@ pub extern crate serde_str_helpers;
 /// impls TryFrom<T> where T: Deref<Target=str> in terms of FromStr.
 ///
 /// If your type implements `FromStr` then it could also implement `TryFrom<T>`
-/// where `T` are various stringly types like `&str`, `String`, `Cow<'a, str>`...
-/// Implementing these conversions as a blanket impl is impossible due to the
-/// conflict with `T: Into<Self>`. Implementing them manually is tedious.
+/// where `T` are various stringly types like `&str`, `String`, `Cow<'a,
+/// str>`... Implementing these conversions as a blanket impl is impossible due
+/// to the conflict with `T: Into<Self>`. Implementing them manually is tedious.
 /// This macro will help you. However, take a look at
 /// `impl_into_stringly_standard` which will help you even more!
 ///
@@ -68,9 +68,9 @@ macro_rules! impl_try_from_stringly {
 /// Calls impl_try_from_stringly!() with a set of standard stringly types.
 ///
 /// A module is generated internally and its name is derived from the type name.
-/// This obviously fails when the type name is generic or contains other non-ident
-/// characters. In such case supply the macro with a second argument which is some
-/// unique identifier.
+/// This obviously fails when the type name is generic or contains other
+/// non-ident characters. In such case supply the macro with a second argument
+/// which is some unique identifier.
 ///
 /// The currently supported types are:
 ///
@@ -88,7 +88,6 @@ macro_rules! impl_try_from_stringly {
 ///
 /// Types from external crates:
 /// * `serde_str_helpers::DeserBorrowStr`
-///
 #[macro_export]
 macro_rules! impl_try_from_stringly_standard {
     ($type:ty) => {
@@ -152,9 +151,9 @@ macro_rules! impl_into_stringly {
 /// Implements `impl_into_stringly` for `$type` and traits with `$type`
 ///
 /// A module is generated internally and its name is derived from the type name.
-/// This obviously fails when the type name is generic or contains other non-ident
-/// characters. In such case supply the macro with a second argument which is some
-/// unique identifier.
+/// This obviously fails when the type name is generic or contains other
+/// non-ident characters. In such case supply the macro with a second argument
+/// which is some unique identifier.
 ///
 /// The currently supported types are:
 ///
@@ -168,7 +167,6 @@ macro_rules! impl_into_stringly {
 /// * `Arc<str>,`
 /// * `Arc<String>,`
 /// * `Arc<Cow<'_, str>>,`
-///
 #[macro_export]
 macro_rules! impl_into_stringly_standard {
     ($type:ty) => {
@@ -208,13 +206,13 @@ mod tests {
     use core::fmt;
 
     #[cfg(feature = "alloc")]
-    use alloc::string::String;
+    use alloc::borrow::Cow;
     #[cfg(feature = "alloc")]
     use alloc::boxed::Box;
     #[cfg(feature = "alloc")]
-    use alloc::borrow::Cow;
-    #[cfg(feature = "alloc")]
     use alloc::rc::Rc;
+    #[cfg(feature = "alloc")]
+    use alloc::string::String;
     #[cfg(feature = "alloc")]
     use alloc::sync::Arc;
 
@@ -236,7 +234,6 @@ mod tests {
             write!(f, "{}", self.0)
         }
     }
-
 
     // Intended for testing clashes, the code itself is irrelevant.
     struct Foo<T>(T);
@@ -265,13 +262,23 @@ mod tests {
         assert_eq!(Number::try_from(<Rc<str>>::from("42")).unwrap().0, 42);
         assert_eq!(Number::try_from(Rc::new(String::from("42"))).unwrap().0, 42);
         assert_eq!(Number::try_from(<Arc<str>>::from("42")).unwrap().0, 42);
-        assert_eq!(Number::try_from(Arc::new(String::from("42"))).unwrap().0, 42);
+        assert_eq!(
+            Number::try_from(Arc::new(String::from("42"))).unwrap().0,
+            42
+        );
     }
 
     #[cfg(all(feature = "serde_str_helpers", feature = "alloc"))]
     #[test]
     fn test_serde_str_helpers() {
-        assert_eq!(Number::try_from(serde_str_helpers::DeserBorrowStr::from(<Cow<'_, str>>::from("42"))).unwrap().0, 42);
+        assert_eq!(
+            Number::try_from(serde_str_helpers::DeserBorrowStr::from(
+                <Cow<'_, str>>::from("42")
+            ))
+            .unwrap()
+            .0,
+            42
+        );
     }
 
     #[cfg(feature = "alloc")]

--- a/stringly_conversions/src/lib.rs
+++ b/stringly_conversions/src/lib.rs
@@ -1,0 +1,250 @@
+// Rust language amplification library providing multiple generic trait
+// implementations, type wrappers, derive macros and other language enhancements
+//
+// Written in 2019-2020 by
+//     Martin Habovstiak <martin.habovstiak@gmail.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the MIT License
+// along with this software.
+// If not, see <https://opensource.org/licenses/MIT>.
+
+//! A crate helping to convert to/from various representations of strings.
+//!
+//! This crate is `no_std` with an optional feature to enable `alloc`.
+
+#![no_std]
+
+#[cfg(feature = "alloc")]
+pub extern crate alloc;
+
+// We republish all supported external crates for access from the macros
+#[cfg(feature = "serde_str_helpers")]
+pub extern crate serde_str_helpers;
+
+/// impls TryFrom<T> where T: Deref<Target=str> in terms of FromStr.
+///
+/// If your type implements `FromStr` then it could also implement `TryFrom<T>`
+/// where `T` are various stringly types like `&str`, `String`, `Cow<'a, str>`...
+/// Implementing these conversions as a blanket impl is impossible due to the
+/// conflict with `T: Into<Self>`. Implementing them manually is tedious.
+/// This macro will help you. However, take a look at
+/// `impl_into_stringly_standard` which will help you even more!
+///
+/// This needs to be a macro instead of blanket imple in order to resolve the
+/// conflict with T: Into<Self>
+#[macro_export]
+macro_rules! impl_try_from_stringly {
+    ($to:ty $(, $from:ty)+ $(,)?) => {
+        $(
+            impl ::core::convert::TryFrom<$from> for $to {
+                type Error = <$to as ::core::str::FromStr>::Err;
+                #[inline]
+                fn try_from(value: $from) -> Result<Self, Self::Error> {
+                    <$to as core::str::FromStr>::from_str(&value)
+                }
+            }
+        )*
+    };
+
+    (@std, $to:ty $(, $from:ty)+ $(,)?) => {
+        $(
+            #[cfg(feature = "std")]
+            impl std::convert::TryFrom<$from> for $to {
+                type Error = <$to as ::core::str::FromStr>::Err;
+                #[inline]
+                fn try_from(value: $from) -> Result<Self, Self::Error> {
+                    <$to>::from_str(&value)
+                }
+            }
+        )*
+    }
+}
+
+/// Calls impl_try_from_stringly!() with a set of standard stringly types.
+///
+/// The currently supported types are:
+///
+/// * `Cow<'_, str>,`
+/// * `Box<str>,`
+/// * `Box<Cow<'_, str>>,`
+/// * `Rc<str>,`
+/// * `Rc<String>,`
+/// * `Rc<Cow<'_, str>>,`
+/// * `Arc<str>,`
+/// * `Arc<String>,`
+/// * `Arc<Cow<'_, str>>,`
+///
+/// Types from external crates:
+/// * 
+///
+#[macro_export]
+macro_rules! impl_try_from_stringly_standard {
+    ($type:ty) => {
+        mod __try_from_stringly_standard {
+            use super::*;
+            #[cfg(feature = "alloc")]
+            use alloc::string::String;
+            #[cfg(feature = "alloc")]
+            use alloc::boxed::Box;
+            #[cfg(feature = "alloc")]
+            use alloc::borrow::Cow;
+            #[cfg(feature = "alloc")]
+            use alloc::rc::Rc;
+            #[cfg(feature = "alloc")]
+            use alloc::sync::Arc;
+
+            impl_try_from_stringly! { $type,
+                &str,
+            }
+
+            #[cfg(feature = "alloc")]
+            impl_try_from_stringly! { $type,
+                String,
+                Cow<'_, str>,
+                Box<str>,
+                Box<Cow<'_, str>>,
+                Rc<str>,
+                Rc<String>,
+                Rc<Cow<'_, str>>,
+                Arc<str>,
+                Arc<String>,
+                Arc<Cow<'_, str>>,
+            }
+
+            #[cfg(feature = "serde_str_helpers")]
+            impl_try_from_stringly!($type, $crate::serde_str_helpers::DeserBorrowStr<'_>);
+        }
+    };
+}
+
+/// Impls From<T> for Stringly where String: Into<Stringly>, T: Display
+#[macro_export]
+macro_rules! impl_into_stringly {
+    ($from:ty $(, $into:ty)+ $(,)?) => {
+        $(
+            impl From<$from> for $into {
+                fn from(value: $from) -> Self {
+                    $crate::alloc::string::ToString::to_string(&value).into()
+                }
+            }
+        )+
+    }
+}
+
+/// Implements `impl_into_stringly` for `$type` and traits with `$type`
+#[macro_export]
+macro_rules! impl_into_stringly_standard {
+    ($type:ty) => {
+        mod __into_stringly_standard {
+            use super::*;
+            #[cfg(feature = "alloc")]
+            use alloc::borrow::Cow;
+            #[cfg(feature = "alloc")]
+            use alloc::rc::Rc;
+            #[cfg(feature = "alloc")]
+            use alloc::sync::Arc;
+
+            #[cfg(feature = "alloc")]
+            impl_into_stringly! { $type,
+                String,
+                Cow<'_, str>,
+                Box<str>,
+                Rc<str>,
+                Rc<String>,
+                Arc<str>,
+                Arc<String>,
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use core::convert::TryFrom;
+    use core::fmt;
+
+    #[cfg(feature = "alloc")]
+    use alloc::string::String;
+    #[cfg(feature = "alloc")]
+    use alloc::boxed::Box;
+    #[cfg(feature = "alloc")]
+    use alloc::borrow::Cow;
+    #[cfg(feature = "alloc")]
+    use alloc::rc::Rc;
+    #[cfg(feature = "alloc")]
+    use alloc::sync::Arc;
+
+    struct Number(u32);
+
+    impl_try_from_stringly_standard!(Number);
+    impl_into_stringly_standard!(Number);
+
+    impl core::str::FromStr for Number {
+        type Err = core::num::ParseIntError;
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            s.parse().map(Number)
+        }
+    }
+
+    impl fmt::Display for Number {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+
+
+    /* This doesn't compile because of missing hygiene
+
+    struct Foo(u32);
+
+    impl_try_from_stringly_standard!(Foo);
+
+    impl core::str::FromStr for Foo {
+        type Err = core::num::ParseIntError;
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            s.parse().map(Foo)
+        }
+    }
+    */
+
+    #[test]
+    fn parse_str() {
+        assert_eq!(Number::try_from("42").unwrap().0, 42);
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn parse_alloc() {
+        assert_eq!(Number::try_from(String::from("42")).unwrap().0, 42);
+        assert_eq!(Number::try_from(<Cow<'_, str>>::from("42")).unwrap().0, 42);
+        assert_eq!(Number::try_from(<Box<str>>::from("42")).unwrap().0, 42);
+        assert_eq!(Number::try_from(<Rc<str>>::from("42")).unwrap().0, 42);
+        assert_eq!(Number::try_from(Rc::new(String::from("42"))).unwrap().0, 42);
+        assert_eq!(Number::try_from(<Arc<str>>::from("42")).unwrap().0, 42);
+        assert_eq!(Number::try_from(Arc::new(String::from("42"))).unwrap().0, 42);
+    }
+
+    #[cfg(all(feature = "serde_str_helpers", feature = "alloc"))]
+    #[test]
+    fn test_serde_str_helpers() {
+        assert_eq!(Number::try_from(serde_str_helpers::DeserBorrowStr::from(<Cow<'_, str>>::from("42"))).unwrap().0, 42);
+    }
+
+    #[test]
+    fn display() {
+        assert_eq!(&*<String>::from(Number(42)), "42");
+        assert_eq!(&*<Cow<'_, str>>::from(Number(42)), "42");
+        assert_eq!(&*<Box<str>>::from(Number(42)), "42");
+        assert_eq!(&*<Rc<str>>::from(Number(42)), "42");
+        assert_eq!(&*<Rc<String>>::from(Number(42)), "42");
+        assert_eq!(&*<Arc<str>>::from(Number(42)), "42");
+        assert_eq!(&*<Arc<String>>::from(Number(42)), "42");
+    }
+}


### PR DESCRIPTION
Some things improved:

* Fixed `&str` conversion
* Use `alloc` instead of `std` - we don't need OS.
* `serde_str_helpers` is optional (default off)

Things to resolve

- [x] It'd be better to generate a unique module name. There's a `paste` crate from reputable developer that may help but not sure if it'll work with arbitrary type names.
- [x] We need to publish `serde_str_helpers` and remove `path = "../serde_str_helpers"` from `Cargo.toml`