### PR TITLE
Prepare for publishing stringly_conversions

### DIFF
--- a/stringly_conversions/Cargo.toml
+++ b/stringly_conversions/Cargo.toml
@@ -1,10 +1,15 @@
 [package]
 name = "stringly_conversions"
 version = "0.1.0"
+description = "A crate helping to convert to/from various representations of strings."
 authors = ["Martin Habovstiak <martin.habovstiak@gmail.com>"]
+keywords = ["macros", "try_from", "string", "no_std", "patterns"]
+categories = ["no-std", "rust-patterns"]
+repository = "https://github.com/LNP-BP/rust-amplify"
+homepage = "https://github.com/LNP-BP"
+license = "MIT"
+readme = "README.md"
 edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
 alloc = []


### PR DESCRIPTION
I will publish `stringly_conversions` after merging this and then make a PR to remove the code from parent crate and only reexport `stringly_conversions` and `DeserBorrowStr`

Regarding `DeserBorrowStr`, I can reexport it under old name (`CowHelper`), which will not affect compatibility but the old name is quite unclear. What should I do? So far I lean towards renaming it, since upstream fixes are as simple as `s/CowHelper/DeserBorrowStr/`. I could also write semver trick but I doubt it's worth the effort (unless you know of many *independent* projects using this crate).