### PR TITLE
Remove requirement on std from `serde_str_helpers`

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,38 @@
+name: Codecov
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  codecov:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install rust nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - name: Build & test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --all-features --no-fail-fast
+        env:
+          CARGO_INCREMENTAL: '0'
+          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
+          RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
+      - id: coverage
+        name: Generate coverage
+        uses: actions-rs/grcov@v0.1.5
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ${{ steps.coverage.outputs.report }}
+          directory: ./coverage/reports/

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        feature: [ serde, std, async, tor ]
+        feature: [ serde, std, async, tor, parse_arg ]
     steps:
       - uses: actions/checkout@v2
       - name: Install rust stable

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Lints
 
 on:
   push:
@@ -10,17 +10,18 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  testing:
+  rustfmt:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Install rust nightly
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: nightly
-            override: true
-      - name: Build & test
-        uses: actions-rs/cargo@v1
+          toolchain: nightly
+          override: true
+          components: rustfmt
+      - uses: actions-rs/cargo@v1
+        name: Lints
         with:
-          command: test
-          args: --workspace --all-features --no-fail-fast
+          command: fmt
+          args: --all -- --check

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,2 +1,3 @@
 wrap_comments = true
 format_code_in_doc_comments = true
+reorder_imports = false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,20 +536,20 @@ dependencies = [
 [[package]]
 name = "serde_str_helpers"
 version = "0.1.0"
-dependencies = [
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "serde_str_helpers"
-version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6009251ec4a3826c297b8a7baade19d73a642a89759d107826ca9ac944cc4a"
 dependencies = [
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_str_helpers"
+version = "0.1.1"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
 ]
 
 [[package]]
@@ -607,7 +607,7 @@ name = "stringly_conversions"
 version = "0.1.0"
 dependencies = [
  "paste",
- "serde_str_helpers 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_str_helpers 0.1.0",
 ]
 
 [[package]]

--- a/serde_str_helpers/Cargo.toml
+++ b/serde_str_helpers/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "serde_str_helpers"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Martin Habovstiak <martin.habovstiak@gmail.com>"]
 edition = "2018"
 description = "Helpers for using serde with strings"
 keywords = ["serde", "deserialization", "zero-copy", "patterns"]
-categories = ["data-structures", "rust-patterns"]
+categories = ["data-structures", "rust-patterns", "no_std"]
 repository = "https://github.com/LNP-BP/rust-amplify"
 homepage = "https://github.com/LNP-BP"
 license = "MIT"

--- a/serde_str_helpers/README.md
+++ b/serde_str_helpers/README.md
@@ -8,6 +8,8 @@ Currently there is only a helper for deserializing stringly values more
 efficiently by avoiding allocation (and copying) in certain cases. New helpers
 may appear in the future.
 
+This crate is `no_std` but **does** require `alloc`.
+
 ## `DeserBorrowStr`
 
 A helper for deserializing using `TryFrom` more efficiently.

--- a/serde_str_helpers/src/lib.rs
+++ b/serde_str_helpers/src/lib.rs
@@ -17,9 +17,14 @@
 //!
 //! Currently there is only a helper for deserializing stringly values more
 //! efficiently by avoiding allocation (and copying) in certain cases.
+//!
+//! This crate is `no_std`, but **does** require `alloc`.
 
-use std::borrow::Cow;
-use std::ops::Deref;
+#![no_std]
+
+extern crate alloc;
+use alloc::borrow::Cow;
+use core::ops::Deref;
 
 /// This is a helper for deserializing using `TryFrom` more efficiently.
 ///
@@ -40,14 +45,14 @@ use std::ops::Deref;
 /// ```
 /// use serde_derive::Deserialize;
 /// use serde_str_helpers::DeserBorrowStr;
-/// use std::convert::TryFrom;
+/// use core::convert::TryFrom;
 ///
 /// #[derive(Deserialize)]
 /// #[serde(try_from = "DeserBorrowStr")]
 /// struct StringlyNumber(u64);
 ///
 /// impl<'a> TryFrom<DeserBorrowStr<'a>> for StringlyNumber {
-///     type Error = std::num::ParseIntError;
+///     type Error = core::num::ParseIntError;
 ///
 ///     fn try_from(value: DeserBorrowStr<'a>) -> Result<Self, Self::Error> {
 ///         value.parse().map(StringlyNumber)
@@ -84,9 +89,10 @@ impl<'a> Deref for DeserBorrowStr<'a> {
 #[cfg(test)]
 mod tests {
     use super::DeserBorrowStr;
-    use std::borrow::Cow;
-    use std::convert::TryFrom;
-    use std::fmt;
+    use alloc::borrow::Cow;
+    use alloc::string::ToString;
+    use core::convert::TryFrom;
+    use core::fmt;
 
     #[test]
     fn actually_borrows_str() {


### PR DESCRIPTION
The library doesn't need an operating system to work, just the
allocator. Thus it makes sense to switch it from `std` to `alloc`.

Do you think I should publish this change on crates.io right after merging or do you want some other changes before it?