### PR TITLE
Fixed reference to paste in stringly_conversions

### DIFF
--- a/stringly_conversions/Cargo.toml
+++ b/stringly_conversions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stringly_conversions"
-version = "0.1.0"
+version = "0.1.1"
 description = "A crate helping to convert to/from various representations of strings."
 authors = ["Martin Habovstiak <martin.habovstiak@gmail.com>"]
 keywords = ["macros", "try_from", "string", "no_std", "patterns"]

--- a/stringly_conversions/src/lib.rs
+++ b/stringly_conversions/src/lib.rs
@@ -22,6 +22,8 @@
 #[cfg(feature = "alloc")]
 pub extern crate alloc;
 
+pub extern crate paste;
+
 // We republish all supported external crates for access from the macros
 #[cfg(feature = "serde_str_helpers")]
 pub extern crate serde_str_helpers;
@@ -94,7 +96,7 @@ macro_rules! impl_try_from_stringly_standard {
         $crate::impl_try_from_stringly_standard!($type, $type);
     };
     ($type:ty, $module_suffix:ty) => {
-        paste::paste! {
+        $crate::paste::paste! {
             #[allow(non_snake_case)]
             mod [<__try_from_stringly_standard_ $module_suffix >] {
                 use super::*;
@@ -173,7 +175,7 @@ macro_rules! impl_into_stringly_standard {
         $crate::impl_into_stringly_standard!($type, $type);
     };
     ($type:ty, $module_suffix:ty) => {
-        paste::paste! {
+        $crate::paste::paste! {
             #[allow(non_snake_case)]
             mod [< __into_stringly_standard_ $type >] {
                 #[allow(unused)]


### PR DESCRIPTION
`paste` was referenced relatively from the crate which caused failures
in downstream crates. This fixes it by reexporting `paste` and then
referencing it using `$crate`.

This blocks moving `rust-amplify::convert` to `stringly_conversions`.
I will yank the previous version after merging.