### PR TITLE
A few more standard conversions for DeserBorrowStr

### DIFF
--- a/serde_str_helpers/Cargo.toml
+++ b/serde_str_helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_str_helpers"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Martin Habovstiak <martin.habovstiak@gmail.com>"]
 edition = "2018"
 description = "Helpers for using serde with strings"


### PR DESCRIPTION
This implements:

* `From<DeserBorrowStr> for String`
* `AsRef<str> for DeserBorrowStr`
* `Borrow<str> for DeserBorrowStr`

These are normally implemented for most stringly types and make use in
generic contexts easier.

This also bumps the version to `0.1.2`.

~~Would appreciate quick review, since I need this. Should be trivial anyway.
I plan to release a new version once this is merged.~~

Actually not that urgent, so don't worry.