### PR TITLE
Fixing `Getters` behavior to match documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+3.9.0
+-----
+- Bumped `derive` dependency version
+
 3.8.2
 -----
 - Feature `hex` becomes default and independent from `std` in `amplify_num`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "amplify"
-version = "3.8.2"
+version = "3.9.0"
 dependencies = [
  "amplify_derive",
  "amplify_num",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "amplify_derive"
-version = "2.8.3"
+version = "2.9.0"
 dependencies = [
  "amplify",
  "amplify_syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amplify"
-version = "3.8.2"
+version = "3.9.0"
 description = "Amplifying Rust language capabilities: multiple generic trait implementations, type wrappers, derive macros"
 authors = ["Dr. Maxim Orlovsky <orlovsky@pandoracore.com>", "Martin Habovstiak <martin.habovstiak@gmail.com>"]
 keywords = ["generics", "core", "no_std", "wrap", "patterns"]
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 libc = { version = "0.2", optional = true }
-amplify_derive = { version = "2.7", path = "./derive", optional = true }
+amplify_derive = { version = "2.8", path = "./derive", optional = true }
 amplify_syn = { version = "1.1", path = "./syn", optional = true }
 amplify_num = { version = "0.2.1", path = "./num" }
 parse_arg = { version = "0.1.4", optional = true }

--- a/derive/CHANGELOG.md
+++ b/derive/CHANGELOG.md
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+2.9.0
+-----
+- Fixing `Getters` behavior to match documentation: if none of getter options
+  are provided a function with the same name as a field is generated returning
+  reference to the field (previously due to a bug this function had `_ref` 
+  suffix)
+
 2.7.2
 -----
 - Using `core` instead of `std` in order to support no_std environment

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amplify_derive"
-version = "2.8.3"
+version = "2.9.0"
 description = "Amplifying Rust language capabilities: derive macros for the 'amplify' library"
 authors = ["Dr. Maxim Orlovsky <orlovsky@pandoracore.com>", "Elichai Turkel <elichai.turkel@gmail.com>"]
 keywords = ["generics", "derive", "wrap", "patterns"]

--- a/derive/src/getters.rs
+++ b/derive/src/getters.rs
@@ -113,8 +113,7 @@ impl GetterDerive {
             || attr.args.contains_key("as_ref")
             || attr.args.contains_key("as_mut"))
         {
-            attr.args
-                .insert("as_ref".to_owned(), ArgValue::from("_ref"));
+            attr.args.insert("as_ref".to_owned(), ArgValue::from(""));
         }
 
         Ok(GetterDerive {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -495,6 +495,8 @@ pub fn derive_as_any(input: TokenStream) -> TokenStream {
 ///     #[getter(all, base_name = "bytes")]
 ///     vec: Vec<u8>,
 ///
+///     defaults: String,
+///
 ///     #[getter(as_copy)]
 ///     pub flag: bool,
 ///
@@ -505,6 +507,8 @@ pub fn derive_as_any(input: TokenStream) -> TokenStream {
 /// let mut one = One::default();
 /// assert_eq!(one.get_bytes_ref(), &Vec::<u8>::default());
 /// *one.get_bytes_mut() = vec![0, 1, 2];
+/// assert_eq!(one.get_defaults(), "");
+/// assert_eq!(one.get_defaults_mut(), "");
 /// assert_eq!(one.get_bytes(), vec![0, 1, 2]);
 /// assert_eq!(one.get_flag(), bool::default());
 /// assert_eq!(one.get_flag_mut(), &mut bool::default());


### PR DESCRIPTION
If none of getter options are provided a function with the same name as a field 
is generated returning reference to the field (previously due to a bug this 
function had `_ref  suffix)