### PR TITLE
add #[display(lowercase)] for enums (and uppercase)

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -166,6 +166,33 @@ use syn::DeriveInput;
 ///     #[display(doc_comments)]
 ///     pub struct UnitStruct;
 ///    ```
+/// 7. Print the name of enum variant in lowercase/uppercase:
+///    ```
+///     # #[macro_use] extern crate amplify_derive;
+///     #[derive(Display)]
+///     #[display(lowercase)]
+///     enum Message {
+///         Quit,
+///         Move { x: i32, y: i32 },
+///         Write(String),
+///         ChangeColor(i32, i32, i32),
+///     }
+///
+///     #[derive(Display)]
+///     #[display(uppercase)]
+///     enum Event {
+///         Init,
+///         Load(Message),
+///     }
+///
+///
+///     assert_eq!(format!("{}", Message::Quit), "quit");
+///     assert_eq!(format!("{}", Message::Move{ x: 1, y: 2 }), "move { x: 1, y: 2 }");
+///     assert_eq!(format!("{}", Message::Write(String::from("msg"))), "write(msg)");
+///     assert_eq!(format!("{}", Message::ChangeColor(255, 0, 0)), "changecolor(255, 0, 0)");
+///     assert_eq!(format!("{}", Event::Init), "INIT");
+///     assert_eq!(format!("{}", Event::Load(Message::ChangeColor(0, 255, 0))), "LOAD(changecolor(0, 255, 0))");
+///    ```
 /// # Example
 ///
 /// Advanced use with enums:


### PR DESCRIPTION
Closes https://github.com/LNP-BP/rust-amplify/issues/92

https://github.com/LNP-BP/rust-amplify/issues/92#issuecomment-995698155
~~I assumed the answer to be `withdata`, because if we do not specify the technique, it currently prints like `Named { .. }`, not showing the contents inside.~~