### PR TITLE
clippy: needless borrow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "amplify_derive"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
  "amplify",
  "amplify_syn",

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amplify_derive"
-version = "2.11.0"
+version = "2.11.1"
 description = "Amplifying Rust language capabilities: derive macros for the 'amplify' library"
 authors = ["Dr. Maxim Orlovsky <orlovsky@pandoracore.com>", "Elichai Turkel <elichai.turkel@gmail.com>"]
 keywords = ["generics", "derive", "wrap", "patterns"]

--- a/derive/src/display.rs
+++ b/derive/src/display.rs
@@ -82,28 +82,28 @@ impl FormattingTrait {
     pub fn into_token_stream2(self, span: Span) -> TokenStream2 {
         match self {
             FormattingTrait::Debug => quote_spanned! { span =>
-                ::core::fmt::Debug::fmt(&self, &mut f)
+                ::core::fmt::Debug::fmt(self, &mut f)
             },
             FormattingTrait::Octal => quote_spanned! { span =>
-                ::core::fmt::Octal::fmt(&self, &mut f)
+                ::core::fmt::Octal::fmt(self, &mut f)
             },
             FormattingTrait::Binary => quote_spanned! { span =>
-                ::core::fmt::Binary::fmt(&self, &mut f)
+                ::core::fmt::Binary::fmt(self, &mut f)
             },
             FormattingTrait::Pointer => quote_spanned! { span =>
-                ::core::fmt::Pointer::fmt(&self, &mut f)
+                ::core::fmt::Pointer::fmt(self, &mut f)
             },
             FormattingTrait::LowerHex => quote_spanned! { span =>
-                ::core::fmt::LowerHex::fmt(&self, &mut f)
+                ::core::fmt::LowerHex::fmt(self, &mut f)
             },
             FormattingTrait::UpperHex => quote_spanned! { span =>
-                ::core::fmt::UpperHex::fmt(&self, &mut f)
+                ::core::fmt::UpperHex::fmt(self, &mut f)
             },
             FormattingTrait::LowerExp => quote_spanned! { span =>
-                ::core::fmt::LowerExp::fmt(&self, &mut f)
+                ::core::fmt::LowerExp::fmt(self, &mut f)
             },
             FormattingTrait::UpperExp => quote_spanned! { span =>
-                ::core::fmt::UpperExp::fmt(&self, &mut f)
+                ::core::fmt::UpperExp::fmt(self, &mut f)
             },
         }
     }


### PR DESCRIPTION
trivial PR; this will shut up `clippy` on AluVM (https://github.com/internet2-org/rust-aluvm/runs/4727706297?check_suite_focus=true). Been ignored on this repo since they were inside `quote` macro