### PR TITLE
follow-up PR on clippy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "amplify_derive"
-version = "2.11.1"
+version = "2.11.2"
 dependencies = [
  "amplify",
  "amplify_syn",

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amplify_derive"
-version = "2.11.1"
+version = "2.11.2"
 description = "Amplifying Rust language capabilities: derive macros for the 'amplify' library"
 authors = ["Dr. Maxim Orlovsky <orlovsky@pandoracore.com>", "Elichai Turkel <elichai.turkel@gmail.com>"]
 keywords = ["generics", "derive", "wrap", "patterns"]

--- a/derive/src/display.rs
+++ b/derive/src/display.rs
@@ -82,28 +82,28 @@ impl FormattingTrait {
     pub fn into_token_stream2(self, span: Span) -> TokenStream2 {
         match self {
             FormattingTrait::Debug => quote_spanned! { span =>
-                ::core::fmt::Debug::fmt(self, &mut f)
+                ::core::fmt::Debug::fmt(&self, f)
             },
             FormattingTrait::Octal => quote_spanned! { span =>
-                ::core::fmt::Octal::fmt(self, &mut f)
+                ::core::fmt::Octal::fmt(&self, f)
             },
             FormattingTrait::Binary => quote_spanned! { span =>
-                ::core::fmt::Binary::fmt(self, &mut f)
+                ::core::fmt::Binary::fmt(&self, f)
             },
             FormattingTrait::Pointer => quote_spanned! { span =>
-                ::core::fmt::Pointer::fmt(self, &mut f)
+                ::core::fmt::Pointer::fmt(&self, f)
             },
             FormattingTrait::LowerHex => quote_spanned! { span =>
-                ::core::fmt::LowerHex::fmt(self, &mut f)
+                ::core::fmt::LowerHex::fmt(&self, f)
             },
             FormattingTrait::UpperHex => quote_spanned! { span =>
-                ::core::fmt::UpperHex::fmt(self, &mut f)
+                ::core::fmt::UpperHex::fmt(&self, f)
             },
             FormattingTrait::LowerExp => quote_spanned! { span =>
-                ::core::fmt::LowerExp::fmt(self, &mut f)
+                ::core::fmt::LowerExp::fmt(&self, f)
             },
             FormattingTrait::UpperExp => quote_spanned! { span =>
-                ::core::fmt::UpperExp::fmt(self, &mut f)
+                ::core::fmt::UpperExp::fmt(&self, f)
             },
         }
     }


### PR DESCRIPTION
Sorry to bother you again, I typo-ed on https://github.com/LNP-BP/rust-amplify/pull/111. What we needed to deref was `&mut std::fmt::Formatter`. Most likely I checked on `stable` compiler yesterday and thought it passed the `clippy` https://github.com/internet2-org/rust-aluvm/issues/38