### PR TITLE
Re-export apfloat package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --features compat --exclude amplify_apfloat
+          args: --features compat
       - name: Derive
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        feature: [ serde, std, alloc, parse_arg, stringly_conversions, rand, c_raw, proc_attr, hex ]
+        feature: [ serde, std, alloc, parse_arg, stringly_conversions, rand, c_raw, proc_attr, hex, apfloat ]
     steps:
       - uses: actions/checkout@v2
       - name: Install rust stable
@@ -26,12 +26,12 @@ jobs:
       - name: Feature ${{matrix.feature}}
         uses: actions-rs/cargo@v1
         with:
-          command: build
+          command: check
           args: --no-default-features --features=${{matrix.feature}}
       - name: Defaults + ${{matrix.feature}}
         uses: actions-rs/cargo@v1
         with:
-          command: build
+          command: check
           args: --features=${{matrix.feature}}
   toolchains:
     runs-on: ubuntu-latest
@@ -49,14 +49,14 @@ jobs:
         if: matrix.toolchain != '1.41.1'
         uses: actions-rs/cargo@v1
         with:
-          command: build
+          command: check
           args: --workspace --all-targets --all-features
-      - name: All features except amplify_apfloat
+      - name: All compat features
         if: matrix.toolchain == '1.41.1'
         uses: actions-rs/cargo@v1
         with:
-          command: build
-          args: --workspace --all-targets --all-features --exclude amplify_apfloat
+          command: check
+          args: --workspace --all-targets --features compat --exclude amplify_apfloat
   ancient:
     runs-on: ubuntu-latest
     steps:
@@ -81,17 +81,17 @@ jobs:
       - name: Main repo
         uses: actions-rs/cargo@v1
         with:
-          command: build
-          args: --all-features
+          command: check
+          args: --features compat --exclude amplify_apfloat
       - name: Derive
         uses: actions-rs/cargo@v1
         with:
-          command: build
+          command: check
           args: --manifest-path ./derive/Cargo.toml
       - name: Syn
         uses: actions-rs/cargo@v1
         with:
-          command: build
+          command: check
           args: --manifest-path ./syn/Cargo.toml
   dependency:
     runs-on: ubuntu-latest
@@ -110,7 +110,7 @@ jobs:
       - name: Build dependency
         uses: actions-rs/cargo@v1
         with:
-          command: build
+          command: check
           args: --verbose
       - name: Clean up
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ version = 3
 name = "amplify"
 version = "3.12.0"
 dependencies = [
+ "amplify_apfloat",
  "amplify_derive",
  "amplify_num",
  "amplify_syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ libc = { version = "0.2", optional = true }
 amplify_derive = { version = "2.10.0", path = "./derive", optional = true }
 amplify_syn = { version = "1.1", path = "./syn", optional = true }
 amplify_num = { version = "0.4.0", path = "./num" }
-amplify_apfloat = { version = "0.1.0", path = "./apfloat", optional = true }
+amplify_apfloat = { version = "0.1.0", path = "./apfloat", no-default-features = true, optional = true }
 parse_arg = { version = "0.1.4", optional = true }
 rand = { version = "0.8.4", optional = true }
 # This strange naming is a workaround for not being able to define required features for a dependency
@@ -35,6 +35,7 @@ stringly_conversions = { version = "0.1.1", optional = true, features = ["alloc"
 [features]
 all = ["serde", "std", "parse_arg", "stringly_conversions", "c_raw", "proc_attr", "derive", "rand", "alloc", "apfloat"]
 default = ["std", "derive", "hex"]
+compat = ["serde", "std", "parse_arg", "stringly_conversions", "c_raw", "proc_attr", "derive", "rand", "alloc"]
 std = ["amplify_num/std", "amplify_apfloat/std"]
 alloc = ["amplify_num/alloc"]
 c_raw = ["libc", "std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,13 @@ toml = { version = "0.5", optional = true }
 stringly_conversions = { version = "0.1.1", optional = true, features = ["alloc"] }
 
 [features]
-all = ["serde", "std", "parse_arg", "stringly_conversions", "c_raw", "proc_attr", "derive", "rand", "alloc", "apfloat"]
+all = ["serde", "std", "parse_arg", "stringly_conversions", "c_raw", "proc_attr", "derive", "rand", "apfloat", "apfloat_std"]
 default = ["std", "derive", "hex"]
-compat = ["serde", "std", "parse_arg", "stringly_conversions", "c_raw", "proc_attr", "derive", "rand", "alloc"]
-std = ["amplify_num/std", "amplify_apfloat/std"]
+compat = ["serde", "std", "parse_arg", "stringly_conversions", "c_raw", "proc_attr", "derive", "rand"]
+std = ["amplify_num/std"]
+apfloat_std = ["amplify_apfloat/std"]
 alloc = ["amplify_num/alloc"]
+apfloat_alloc = ["amplify_apfloat/alloc"]
 c_raw = ["libc", "std"]
 hex = ["amplify_num/hex"]
 apfloat = ["amplify_apfloat"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ libc = { version = "0.2", optional = true }
 amplify_derive = { version = "2.10.0", path = "./derive", optional = true }
 amplify_syn = { version = "1.1", path = "./syn", optional = true }
 amplify_num = { version = "0.4.0", path = "./num" }
+amplify_apfloat = { version = "0.1.0", path = "./apfloat", optional = true }
 parse_arg = { version = "0.1.4", optional = true }
 rand = { version = "0.8.4", optional = true }
 # This strange naming is a workaround for not being able to define required features for a dependency
@@ -32,12 +33,13 @@ toml = { version = "0.5", optional = true }
 stringly_conversions = { version = "0.1.1", optional = true, features = ["alloc"] }
 
 [features]
-all = ["serde", "std", "parse_arg", "stringly_conversions", "c_raw", "proc_attr", "derive", "rand", "alloc"]
+all = ["serde", "std", "parse_arg", "stringly_conversions", "c_raw", "proc_attr", "derive", "rand", "alloc", "apfloat"]
 default = ["std", "derive", "hex"]
-std = ["amplify_num/std"]
+std = ["amplify_num/std", "amplify_apfloat/std"]
 alloc = ["amplify_num/alloc"]
 c_raw = ["libc", "std"]
 hex = ["amplify_num/hex"]
+apfloat = ["amplify_apfloat"]
 proc_attr = ["amplify_syn"]
 derive = ["amplify_derive"]
 serde = ["serde_crate", "std",

--- a/apfloat/Cargo.toml
+++ b/apfloat/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/LNP-BP/rust-amplify"
 homepage = "https://github.com/LNP-BP"
 categories = ["no-std"]
-readme = "README.md"
+readme = "../README.md"
 keywords = ["float"]
 
 [features]

--- a/apfloat/Cargo.toml
+++ b/apfloat/Cargo.toml
@@ -12,8 +12,9 @@ keywords = ["float"]
 
 [features]
 default = ["std"]
-std = []
+alloc = ["amplify_num/alloc"]
+std = ["amplify_num/std"]
 
 [dependencies]
-amplify_num = { version = "0.4.0", path = "../num" }
+amplify_num = { version = "0.4.0", path = "../num", no-default-features = true }
 bitflags = "1.0"

--- a/apfloat/src/ieee.rs
+++ b/apfloat/src/ieee.rs
@@ -17,6 +17,7 @@ use std::fmt::{self, Write};
 use std::marker::PhantomData;
 use std::mem;
 use std::ops::Neg;
+#[cfg(any(feature = "std", feature = "alloc"))]
 use std::vec::Vec;
 
 #[must_use]
@@ -323,6 +324,7 @@ impl<S> Neg for IeeeFloat<S> {
     }
 }
 
+#[cfg(any(feature = "std", feature = "alloc"))]
 /// Prints this value as a decimal string.
 ///
 /// \param precision The maximum number of digits of
@@ -1210,6 +1212,7 @@ impl<S: Semantics> Float for IeeeFloat<S> {
         .normalize(round, Loss::ExactlyZero)
     }
 
+    #[cfg(any(feature = "std", feature = "alloc"))]
     fn from_str_r(mut s: &str, mut round: Round) -> Result<StatusAnd<Self>, ParseError> {
         if s.is_empty() {
             return Err(ParseError("Invalid string length"));
@@ -1856,6 +1859,7 @@ impl<S: Semantics> IeeeFloat<S> {
         Ok(r.normalize(round, loss.unwrap_or(Loss::ExactlyZero)))
     }
 
+    #[cfg(any(feature = "std", feature = "alloc"))]
     fn from_decimal_string(s: &str, round: Round) -> Result<StatusAnd<Self>, ParseError> {
         // Given a normal decimal floating point number of the form
         //

--- a/apfloat/src/lib.rs
+++ b/apfloat/src/lib.rs
@@ -60,7 +60,8 @@ extern crate bitflags;
 /// This replaces `std` in builds with `core`.
 #[cfg(not(feature = "std"))]
 mod std {
-    pub use alloc::{boxed, slice, string, vec};
+    #[cfg(feature = "alloc")]
+    pub use alloc::vec;
     pub use core::*;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ pub use amplify_derive::{Wrapper, Display, AsAny, From, Getters, Error};
 #[macro_use]
 extern crate serde_crate as serde;
 
-pub extern crate amplify_num as num;
+extern crate amplify_num;
 #[cfg(any(test, feature = "hex"))]
 pub use num::hex;
 #[cfg(feature = "stringly_conversions")]
@@ -76,6 +76,23 @@ mod to_serde_string;
 
 #[cfg(feature = "std")]
 pub mod flags;
+
+pub mod num {
+    //! Custom-sized numeric types
+    //!
+    //! Implementation of a various integer types with custom bit dimension. These
+    //! includes:
+    //! * large signed and unsigned integers, named *gib int types* (256, 512,
+    //!   1024-bit)
+    //! * custom sub-8 bit unsigned integers, named *small int types (5-, 6-, 7-bit)
+    //! * 24-bit signed integer.
+    //!
+    //! The functions here are designed to be fast.
+
+    pub use amplify_num::*;
+    #[cfg(feature = "apfloat")]
+    pub use amplify_apfloat as apfloat;
+}
 
 pub use crate::as_any::AsAny;
 pub use crate::bipolar::Bipolar;


### PR DESCRIPTION
There was incorrect setup for `std` and `alloc`-related features for apfloat package, which I have fixed

@6293 please review (I can't assign to you the review before you accept invitation to the org/repo I've sent you)