### PR TITLE
WASM in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - uses: Swatinem/rust-cache@v2
       - name: Feature ${{matrix.feature}}
         uses: actions-rs/cargo@v1
         with:
@@ -45,6 +46,7 @@ jobs:
         with:
           toolchain: ${{matrix.toolchain}}
           override: true
+      - uses: Swatinem/rust-cache@v2
       - name: All features
         if: matrix.toolchain != '1.41.1'
         uses: actions-rs/cargo@v1
@@ -68,6 +70,7 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - uses: Swatinem/rust-cache@v2
       - name: Create dependency
         run: |
           cargo new dep_test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,7 @@ jobs:
           toolchain: 1.52.0
           override: true
           components: rustfmt
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         name: Formatting
         with:
@@ -35,11 +36,31 @@ jobs:
           toolchain: 1.52.0
           override: true
           components: clippy
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         name: Clippy
         with:
           command: clippy
           args: --workspace --all-features
+  wasm-clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install rustc 1.52.0
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.52.0
+          override: true
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - uses: jetli/wasm-pack-action@v0.3.0
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+      - uses: actions-rs/cargo@v1
+        name: Clippy
+        with:
+          command: clippy
+          args: --workspace --all-features --target wasm32-unknown-unknown
   doc:
     runs-on: ubuntu-latest
     steps:
@@ -50,6 +71,7 @@ jobs:
           toolchain: nightly
           override: true
           components: rust-docs
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         name: Clippy
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,24 @@ jobs:
         with:
             toolchain: nightly
             override: true
+      - uses: Swatinem/rust-cache@v2
       - name: Build & test
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --workspace --all-features --no-fail-fast
+  wasm-testing:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install rust nightly
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            override: true
+      - uses: Swatinem/rust-cache@v2
+      - uses: jetli/wasm-pack-action@v0.3.0
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+      - name: Test in headless Chrome
+        run: wasm-pack test --headless --chrome

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "parse_arg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,6 +11,7 @@ dependencies = [
  "amplify_num",
  "amplify_syn",
  "criterion",
+ "getrandom",
  "libc",
  "parse_arg",
  "rand",
@@ -20,6 +21,8 @@ dependencies = [
  "softposit",
  "stringly_conversions 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -105,6 +108,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +152,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -274,8 +293,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -319,6 +340,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
+name = "js-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +365,15 @@ name = "linked-hash-map"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "memchr"
@@ -369,6 +408,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "parse_arg"
@@ -550,6 +595,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,6 +768,106 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d2fff962180c3fadf677438054b1db62bee4aa32af26a45388af07d1287e1d"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4683da3dfc016f704c9f82cf401520c4f1cb3ee440f7f52b3d6ac29506a49ca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,10 @@
 name = "amplify"
 version = "3.13.0"
 description = "Amplifying Rust language capabilities: multiple generic trait implementations, type wrappers, derive macros"
-authors = ["Dr. Maxim Orlovsky <orlovsky@pandoracore.com>", "Martin Habovstiak <martin.habovstiak@gmail.com>"]
+authors = [
+    "Dr. Maxim Orlovsky <orlovsky@pandoracore.com>",
+    "Martin Habovstiak <martin.habovstiak@gmail.com>",
+]
 keywords = ["generics", "core", "no_std", "wrap", "patterns"]
 categories = ["data-structures", "no-std", "rust-patterns"]
 repository = "https://github.com/LNP-BP/rust-amplify"
@@ -10,7 +13,14 @@ homepage = "https://github.com/LNP-BP"
 license = "MIT"
 readme = "README.md"
 edition = "2018"
-exclude = [".github", "derive", "syn", "num", "serde_str_helpers", "stringly_conversions"]
+exclude = [
+    ".github",
+    "derive",
+    "syn",
+    "num",
+    "serde_str_helpers",
+    "stringly_conversions",
+]
 
 [lib]
 name = "amplify"
@@ -26,21 +36,53 @@ parse_arg = { version = "0.1.4", optional = true }
 rand = { version = "0.8.4", optional = true }
 # This strange naming is a workaround for not being able to define required features for a dependency
 # See https://github.com/rust-lang/api-guidelines/issues/180 for the explanation and references.
-serde_crate = { package = "serde", version = "1.0", features = ["derive"], optional = true }
+serde_crate = { package = "serde", version = "1.0", features = [
+    "derive",
+], optional = true }
 serde_json = { version = "1.0", optional = true }
 serde_yaml = { version = "0.8", optional = true }
 toml = { version = "0.5", optional = true }
-stringly_conversions = { version = "0.1.1", optional = true, features = ["alloc"] }
+stringly_conversions = { version = "0.1.1", optional = true, features = [
+    "alloc",
+] }
 
 # avoid building criterion in 1.41.1 CI
 [target.'cfg(bench)'.dev-dependencies]
 criterion = "0.2.11"
 softposit = "0.3.9"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"
+rand = { version = "0.8.4", optional = true }
+getrandom = { version = "0.2", features = ["js"], optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3"
+
 [features]
-all = ["serde", "std", "parse_arg", "stringly_conversions", "c_raw", "proc_attr", "derive", "rand", "apfloat", "apfloat_std"]
+all = [
+    "serde",
+    "std",
+    "parse_arg",
+    "stringly_conversions",
+    "c_raw",
+    "proc_attr",
+    "derive",
+    "rand",
+    "apfloat",
+    "apfloat_std",
+]
 default = ["std", "derive", "hex"]
-compat = ["serde", "std", "parse_arg", "stringly_conversions", "c_raw", "proc_attr", "derive", "rand"]
+compat = [
+    "serde",
+    "std",
+    "parse_arg",
+    "stringly_conversions",
+    "c_raw",
+    "proc_attr",
+    "derive",
+    "rand",
+]
 std = ["amplify_num/std"]
 apfloat_std = ["amplify_apfloat/std"]
 alloc = ["amplify_num/alloc"]
@@ -50,15 +92,75 @@ hex = ["amplify_num/hex"]
 apfloat = ["amplify_apfloat"]
 proc_attr = ["amplify_syn"]
 derive = ["amplify_derive"]
-serde = ["serde_crate", "std",
-         "serde_yaml", "serde_json", "toml",
-         "amplify_num/serde",
-         "stringly_conversions",
-         "stringly_conversions/alloc",
-         "stringly_conversions/serde_str_helpers"]
+serde = [
+    "serde_crate",
+    "std",
+    "serde_yaml",
+    "serde_json",
+    "toml",
+    "amplify_num/serde",
+    "stringly_conversions",
+    "stringly_conversions/alloc",
+    "stringly_conversions/serde_str_helpers",
+]
+
+[target.'cfg(target_arch = "wasm32")'.features]
+all = [
+    "serde",
+    "std",
+    "parse_arg",
+    "stringly_conversions",
+    "c_raw",
+    "proc_attr",
+    "derive",
+    "rand",
+    "getrandom",
+    "apfloat",
+    "apfloat_std",
+]
+default = ["std", "derive", "hex"]
+compat = [
+    "serde",
+    "std",
+    "parse_arg",
+    "stringly_conversions",
+    "c_raw",
+    "proc_attr",
+    "derive",
+    "rand",
+    "getrandom",
+]
+std = ["amplify_num/std"]
+apfloat_std = ["amplify_apfloat/std"]
+alloc = ["amplify_num/alloc"]
+apfloat_alloc = ["amplify_apfloat/alloc"]
+c_raw = ["libc", "std"]
+hex = ["amplify_num/hex"]
+apfloat = ["amplify_apfloat"]
+proc_attr = ["amplify_syn"]
+derive = ["amplify_derive"]
+serde = [
+    "serde_crate",
+    "std",
+    "serde_yaml",
+    "serde_json",
+    "toml",
+    "amplify_num/serde",
+    "stringly_conversions",
+    "stringly_conversions/alloc",
+    "stringly_conversions/serde_str_helpers",
+]
 
 [workspace]
-members = [".", "num", "apfloat", "derive", "syn", "serde_str_helpers", "stringly_conversions"]
+members = [
+    ".",
+    "num",
+    "apfloat",
+    "derive",
+    "syn",
+    "serde_str_helpers",
+    "stringly_conversions",
+]
 default-members = ["."]
 
 [[bench]]


### PR DESCRIPTION
- [x] Add wasm-pack and wasm32 target to lint and test in CI.
- [x] Add caching to most actions to speed up CI builds.
- [x] Add features needed for wasm-pack to compile to headless chrome.

This PR does not_resolve #143, but it provides the tooling necessary to debug the issues.