### PR TITLE
Improvements to confined collections, part I

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        feature: [ serde, std, alloc, stringly_conversions, rand, c_raw, proc_attr, hex, apfloat ]
+        feature: [ serde, std, alloc, stringly_conversions, rand, smallvec, indexmap, c_raw, proc_attr, hex, apfloat ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ Change Log
 4.10.0
 ------
 
+- New `SmallVec` support in confined collections via `smallvec` feature
+- New `IndexSet` and `IndexMap` support in confined collections via `indexmap` feature
 - New `CursorDeque` implementation in `io` module, extending over smart pointers wrapping `VecDeque`
 - Updated CI: added support for ubuntu-24.04.arm runners
 - General chore and clippy lint fixes
-- confinement: add `IndexSet` and `IndexMap` support via `indexmap` feature
 
 4.9.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Change Log
 - New `SmallVec` support in confined collections via `smallvec` feature
 - New `IndexSet` and `IndexMap` support in confined collections via `indexmap` feature
 - New `CursorDeque` implementation in `io` module, extending over smart pointers wrapping `VecDeque`
+- New non-failing `first` and `last` methods in confined non-empty collections
 - Updated CI: added support for ubuntu-24.04.arm, macos-15-intel and windows-11-arm runners
 - General chore and clippy lint fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Change Log
 - New `CursorDeque` implementation in `io` module, extending over smart pointers wrapping `VecDeque`
 - Updated CI: added support for ubuntu-24.04.arm runners
 - General chore and clippy lint fixes
+- confinement: add `IndexMap` support via `indexmap` feature
 
 4.9.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+4.10.0
+------
+
+- New `CursorDeque` implementation in `io` module, extending over smart pointers wrapping `VecDeque`
+- Updated CI: added support for ubuntu-24.04.arm runners
+- General chore and clippy lint fixes
+
 4.9.0
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,85 @@ Change Log
   `Confinement::with_mut`)
 - add `retain` and `try_retain` to a keyed collection based confinements
 - deprecate `ByteArray` methods having `_unsafe` suffix
+- add `MultiError` type for collecting multiple errors
+
+4.8.0
+-----
+
+- fix `alloc`/`std` macro ambiguity
+
+4.7.1
+-----
+
+- confinement: add `VecDeque` `truncate` and `drain` methods
+
+4.7.0
+-----
+
+- maintenance release
+
+4.6.2
+-----
+
+- MSRV bump to 1.75.0 due to use of `impl` in trait method returns
+- confinement: rename `_unchecked` names with `_checked` suffix
+- confinement: deprecate general macros
+- confinement: add blob construction macros
+- confinement: add `confined_s` macro
+- confinement: add `Confined*` type aliases
+- confinement: rename `_unsafe` to `_unchecked`
+- confinement: add `values_mut` method to `KeyedCollections`
+- confinement: support `entry` method for map confinements
+- confinement: deprecate `*inner` methods and replace with better names
+- confinement: remove `Wrapper` implementation
+
+4.6.1
+-----
+
+- fix no-std build
+- fix rust v1.80 compatibility
+
+4.6.0
+-----
+
+- MSRV bump to 1.69.0
+- traits: export raw traits
+- remove `serde` JSON, YAML, TOML as MSRV breakers
+
+4.5.1
+-----
+
+- confinement: add `Vec::get_mut` proxy
+
+4.5.0
+-----
+
+- chore: update dependencies
+
+4.4.0
+-----
+
+- macro: provide no-std versions
+- macro: add collection constructions macro with automatic `to_owned`
+- confinement: implement hex traits for `Vec<u8>`-based confinements
+
+4.3.0
+-----
+
+- chore: bump MSRV and `amplify-derive` version
+- confinement: add `Confined<Vec<T>>` convenience APIs (`from_slice_unsafe`, `try_from_slice`,
+  `as_slice`, `into_vec`)
+- confinement: add `Confined::from_iter_unsafe` constructor
+
+4.2.0
+-----
+
+- array: add new `ByteArray` trait, deprecate `RawArray`
+- array: add `ByteArray` methods to `Array` type
+- array: add dedicated `FromSliceError` type
+- array: deprecate `Array::from_slice`, add `Array::copy_from_slice`
+- array: fix `Display` implementation
+- confinement: add `Collection::from_collection_unsafe`
 
 4.1.1
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Change Log
 - New `CursorDeque` implementation in `io` module, extending over smart pointers wrapping `VecDeque`
 - Updated CI: added support for ubuntu-24.04.arm runners
 - General chore and clippy lint fixes
-- confinement: add `IndexMap` support via `indexmap` feature
+- confinement: add `IndexSet` and `IndexMap` support via `indexmap` feature
 
 4.9.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Change Log
 - New `SmallVec` support in confined collections via `smallvec` feature
 - New `IndexSet` and `IndexMap` support in confined collections via `indexmap` feature
 - New `CursorDeque` implementation in `io` module, extending over smart pointers wrapping `VecDeque`
-- Updated CI: added support for ubuntu-24.04.arm runners
+- Updated CI: added support for ubuntu-24.04.arm, macos-15-intel and windows-11-arm runners
 - General chore and clippy lint fixes
 
 4.9.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "smallvec",
  "stringly_conversions",
  "wasm-bindgen",
  "wasm-bindgen-test",
@@ -350,6 +351,15 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "stringly_conversions"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,9 +145,9 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,7 @@ dependencies = [
  "ascii",
  "getrandom 0.2.16",
  "getrandom 0.3.3",
+ "indexmap",
  "libc",
  "rand",
  "serde",
@@ -103,6 +104,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +134,24 @@ dependencies = [
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -270,18 +295,28 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "amplify"
-version = "4.9.0"
+version = "4.10.0"
 dependencies = [
  "amplify_apfloat",
  "amplify_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ all = [
     "rand",
     "apfloat",
     "apfloat_std",
+    "indexmap",
 ]
 default = ["std", "derive", "hex"]
 std = ["amplify_num/std", "alloc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amplify"
-version = "4.9.0"
+version = "4.10.0"
 description = "Amplifying Rust language capabilities: multiple generic trait implementations, type wrappers, derive macros"
 authors = [
     "Dr. Maxim Orlovsky <orlovsky@ubideco.org>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rand = { version = "0.9.1", optional = true }
 # See https://github.com/rust-lang/api-guidelines/issues/180 for the explanation and references.
 serde = { version = "1.0", features = ["derive"], optional = true }
 stringly_conversions = { version = "0.1.1", optional = true, features = ["alloc"] }
-indexmap = { version = "2", optional = true }
+indexmap = { version = "2.11", optional = true }
 smallvec = { version = "1.13", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ rand = { version = "0.9.1", optional = true }
 # See https://github.com/rust-lang/api-guidelines/issues/180 for the explanation and references.
 serde_crate = { package = "serde", version = "1.0", features = ["derive"], optional = true }
 stringly_conversions = { version = "0.1.1", optional = true, features = ["alloc"] }
+indexmap-crate = { package = "indexmap", version = "2", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"
@@ -70,6 +71,7 @@ hex = ["amplify_num/hex"]
 apfloat = ["amplify_apfloat"]
 proc_attr = ["amplify_syn"]
 derive = ["amplify_derive"]
+indexmap = ["indexmap-crate"]
 serde = [
     "serde_crate",
     "std",
@@ -78,4 +80,5 @@ serde = [
     "stringly_conversions",
     "stringly_conversions/alloc",
     "stringly_conversions/serde_str_helpers",
+    "indexmap-crate?/serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,10 +33,10 @@ ascii = "1.1.0"
 rand = { version = "0.9.1", optional = true }
 # This strange naming is a workaround for not being able to define required features for a dependency
 # See https://github.com/rust-lang/api-guidelines/issues/180 for the explanation and references.
-serde_crate = { package = "serde", version = "1.0", features = ["derive"], optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 stringly_conversions = { version = "0.1.1", optional = true, features = ["alloc"] }
-indexmap-crate = { package = "indexmap", version = "2", optional = true }
-smallvec-crate = { package = "smallvec", version = "1.13", optional = true }
+indexmap = { version = "2", optional = true }
+smallvec = { version = "1.13", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"
@@ -74,16 +74,16 @@ hex = ["amplify_num/hex"]
 apfloat = ["amplify_apfloat"]
 proc_attr = ["amplify_syn"]
 derive = ["amplify_derive"]
-indexmap = ["indexmap-crate"]
-smallvec = ["smallvec-crate"]
+indexmap = ["dep:indexmap"]
+smallvec = ["dep:smallvec"]
 serde = [
-    "serde_crate",
+    "dep:serde",
     "std",
     "amplify_num/serde",
     "ascii/serde",
     "stringly_conversions",
     "stringly_conversions/alloc",
     "stringly_conversions/serde_str_helpers",
-    "indexmap-crate?/serde",
-    "smallvec-crate?/serde",
+    "indexmap?/serde",
+    "smallvec?/serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ rand = { version = "0.9.1", optional = true }
 serde_crate = { package = "serde", version = "1.0", features = ["derive"], optional = true }
 stringly_conversions = { version = "0.1.1", optional = true, features = ["alloc"] }
 indexmap-crate = { package = "indexmap", version = "2", optional = true }
+smallvec-crate = { package = "smallvec", version = "1.13", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"
@@ -61,6 +62,7 @@ all = [
     "apfloat",
     "apfloat_std",
     "indexmap",
+    "smallvec",
 ]
 default = ["std", "derive", "hex"]
 std = ["amplify_num/std", "alloc"]
@@ -73,6 +75,7 @@ apfloat = ["amplify_apfloat"]
 proc_attr = ["amplify_syn"]
 derive = ["amplify_derive"]
 indexmap = ["indexmap-crate"]
+smallvec = ["smallvec-crate"]
 serde = [
     "serde_crate",
     "std",
@@ -82,4 +85,5 @@ serde = [
     "stringly_conversions/alloc",
     "stringly_conversions/serde_str_helpers",
     "indexmap-crate?/serde",
+    "smallvec-crate?/serde",
 ]

--- a/src/collection/array.rs
+++ b/src/collection/array.rs
@@ -641,8 +641,8 @@ pub(crate) mod serde_helpers {
 
     use core::fmt;
     use serde::{Deserialize, Deserializer, Serializer, Serialize};
-    use serde_crate::de::{SeqAccess, Visitor};
-    use serde_crate::ser::SerializeTuple;
+    use serde::de::{SeqAccess, Visitor};
+    use serde::ser::SerializeTuple;
 
     use crate::Array;
     use crate::hex::{FromHex, ToHex};

--- a/src/collection/confinement.rs
+++ b/src/collection/confinement.rs
@@ -1165,8 +1165,8 @@ impl<const MIN_LEN: usize, const MAX_LEN: usize> Confined<String, MIN_LEN, MAX_L
     /// doesn't shorten more than the confinement requirement. Errors
     /// otherwise.
     pub fn remove(&mut self, index: usize) -> Result<char, Error> {
-        self.check_undersize()?;
         self.check_boundary(index)?;
+        self.check_undersize()?;
         Ok(self.0.remove(index))
     }
 }
@@ -1184,8 +1184,8 @@ impl<const MIN_LEN: usize, const MAX_LEN: usize> Confined<AsciiString, MIN_LEN, 
     /// doesn't shorten more than the confinement requirement. Errors
     /// otherwise.
     pub fn remove(&mut self, index: usize) -> Result<AsciiChar, Error> {
-        self.check_undersize()?;
         self.check_boundary(index)?;
+        self.check_undersize()?;
         Ok(self.0.remove(index))
     }
 }
@@ -1261,8 +1261,8 @@ impl<T, const MIN_LEN: usize, const MAX_LEN: usize> Confined<Vec<T>, MIN_LEN, MA
     /// length will be less than the confinement requirement. Returns the
     /// removed element otherwise.
     pub fn remove(&mut self, index: usize) -> Result<T, Error> {
-        self.check_undersize()?;
         self.check_boundary(index)?;
+        self.check_undersize()?;
         Ok(self.0.remove(index))
     }
 
@@ -1343,8 +1343,8 @@ impl<A: smallvec::Array, const MIN_LEN: usize, const MAX_LEN: usize>
     /// length will be less than the confinement requirement. Returns the
     /// removed element otherwise.
     pub fn remove(&mut self, index: usize) -> Result<A::Item, Error> {
-        self.check_undersize()?;
         self.check_boundary(index)?;
+        self.check_undersize()?;
         Ok(self.0.remove(index))
     }
 
@@ -1397,8 +1397,8 @@ impl<T, const MIN_LEN: usize, const MAX_LEN: usize> Confined<VecDeque<T>, MIN_LE
     /// length will be less than the confinement requirement. Returns the
     /// removed element otherwise.
     pub fn remove(&mut self, index: usize) -> Result<T, Error> {
-        self.check_undersize()?;
         self.check_boundary(index)?;
+        self.check_undersize()?;
         Ok(self.0.remove(index).expect("element within the length"))
     }
 
@@ -2249,7 +2249,7 @@ macro_rules! tiny_imap {
         $crate::confinement::TinyIndexMap::new()
     };
     { $($key:expr => $value:expr),+ $(,)? } => {
-        $crate::confinement::TinyIndexMap::try_from($crate::confinement::indexmap::IndexMap::from_iter([$(($key, $value)),+]))
+        $crate::confinement::TinyIndexMap::try_from(::core::iter::FromIterator::from_iter([$(($key, $value)),+]))
             .expect("inline tiny_imap literal contains invalid number of items")
     }
 }
@@ -2263,7 +2263,7 @@ macro_rules! small_imap {
         $crate::confinement::SmallIndexMap::new()
     };
     { $($key:expr => $value:expr),+ $(,)? } => {
-        $crate::confinement::SmallIndexMap::try_from($crate::confinement::indexmap::IndexMap::from_iter([$(($key, $value)),+]))
+        $crate::confinement::SmallIndexMap::try_from(::core::iter::FromIterator::from_iter([$(($key, $value)),+]))
             .expect("inline small_imap literal contains invalid number of items")
     }
 }
@@ -2277,7 +2277,7 @@ macro_rules! medium_imap {
         $crate::confinement::MediumIndexMap::new()
     };
     { $($key:expr => $value:expr),+ $(,)? } => {
-        $crate::confinement::MediumIndexMap::try_from($crate::confinement::indexmap::IndexMap::from_iter([$(($key, $value)),+]))
+        $crate::confinement::MediumIndexMap::try_from(::core::iter::FromIterator::from_iter([$(($key, $value)),+]))
             .expect("inline medium_imap literal contains invalid number of items")
     }
 }
@@ -2291,7 +2291,7 @@ macro_rules! tiny_iset {
         $crate::confinement::TinyIndexSet::new()
     };
     ($($x:expr),+ $(,)?) => (
-        $crate::confinement::TinyIndexSet::try_from($crate::confinement::indexmap::IndexSet::from_iter([$($x,)+]))
+        $crate::confinement::TinyIndexSet::try_from(::core::iter::FromIterator::from_iter([$($x,)+]))
             .expect("inline tiny_iset literal contains invalid number of items")
     )
 }
@@ -2305,7 +2305,7 @@ macro_rules! small_iset {
         $crate::confinement::SmallIndexSet::new()
     };
     ($($x:expr),+ $(,)?) => (
-        $crate::confinement::SmallIndexSet::try_from($crate::confinement::indexmap::IndexSet::from_iter([$($x,)+]))
+        $crate::confinement::SmallIndexSet::try_from(::core::iter::FromIterator::from_iter([$($x,)+]))
             .expect("inline small_iset literal contains invalid number of items")
     )
 }
@@ -2319,7 +2319,7 @@ macro_rules! medium_iset {
         $crate::confinement::MediumIndexSet::new()
     };
     ($($x:expr),+ $(,)?) => (
-        $crate::confinement::MediumIndexSet::try_from($crate::confinement::indexmap::IndexSet::from_iter([$($x,)+]))
+        $crate::confinement::MediumIndexSet::try_from(::core::iter::FromIterator::from_iter([$($x,)+]))
             .expect("inline medium_iset literal contains invalid number of items")
     )
 }
@@ -2333,7 +2333,7 @@ macro_rules! tiny_svec {
         $crate::confinement::TinySmallVec::new()
     };
     ($($x:expr),+ $(,)?) => (
-        $crate::confinement::TinySmallVec::try_from($crate::confinement::smallvec::SmallVec::from_iter([$($x,)+]))
+        $crate::confinement::TinySmallVec::try_from(::core::iter::FromIterator::from_iter([$($x,)+]))
             .expect("inline tiny_svec literal contains invalid number of items")
     )
 }
@@ -2347,7 +2347,7 @@ macro_rules! small_svec {
         $crate::confinement::SmallSmallVec::new()
     };
     ($($x:expr),+ $(,)?) => (
-        $crate::confinement::SmallSmallVec::try_from($crate::confinement::smallvec::SmallVec::from_iter([$($x,)+]))
+        $crate::confinement::SmallSmallVec::try_from(::core::iter::FromIterator::from_iter([$($x,)+]))
             .expect("inline small_svec literal contains invalid number of items")
     )
 }
@@ -2361,7 +2361,7 @@ macro_rules! medium_svec {
         $crate::confinement::MediumSmallVec::new()
     };
     ($($x:expr),+ $(,)?) => (
-        $crate::confinement::MediumSmallVec::try_from($crate::confinement::smallvec::SmallVec::from_iter([$($x,)+]))
+        $crate::confinement::MediumSmallVec::try_from(::core::iter::FromIterator::from_iter([$($x,)+]))
             .expect("inline medium_svec literal contains invalid number of items")
     )
 }

--- a/src/collection/confinement.rs
+++ b/src/collection/confinement.rs
@@ -34,6 +34,8 @@ use std::{
 };
 #[cfg(feature = "indexmap")]
 pub use indexmap_crate as indexmap;
+#[cfg(feature = "smallvec")]
+pub use smallvec_crate as smallvec;
 use amplify_num::hex;
 use amplify_num::hex::{FromHex, ToHex};
 use ascii::{AsAsciiStrError, AsciiChar, AsciiString};
@@ -471,6 +473,27 @@ impl<K: Eq + Hash, V> KeyedCollection for indexmap::IndexMap<K, V> {
 
     fn retain(&mut self, f: impl FnMut(&K, &mut V) -> bool) {
         indexmap::IndexMap::retain(self, f)
+    }
+}
+
+#[cfg(feature = "smallvec")]
+impl<A: smallvec::Array> Collection for smallvec::SmallVec<A> {
+    type Item = A::Item;
+
+    fn with_capacity(capacity: usize) -> Self {
+        smallvec::SmallVec::with_capacity(capacity)
+    }
+
+    fn len(&self) -> usize {
+        smallvec::SmallVec::len(self)
+    }
+
+    fn push(&mut self, elem: Self::Item) {
+        smallvec::SmallVec::push(self, elem);
+    }
+
+    fn clear(&mut self) {
+        smallvec::SmallVec::clear(self)
     }
 }
 
@@ -1261,6 +1284,88 @@ impl<T, const MIN_LEN: usize, const MAX_LEN: usize> Confined<Vec<T>, MIN_LEN, MA
     }
 }
 
+#[cfg(feature = "smallvec")]
+impl<A: smallvec::Array, const MIN_LEN: usize, const MAX_LEN: usize>
+    Confined<smallvec::SmallVec<A>, MIN_LEN, MAX_LEN>
+{
+    /// Constructs confinement out of slice of items. Does allocation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the size of the slice doesn't match the confinement type
+    /// bounds.
+    #[inline]
+    pub fn from_slice_checked(slice: &[A::Item]) -> Self
+    where
+        A::Item: Clone,
+    {
+        assert!(slice.len() >= MIN_LEN && slice.len() <= MAX_LEN);
+        Self(smallvec::SmallVec::from_iter(slice.iter().cloned()))
+    }
+
+    /// Constructs confinement out of slice of items. Does allocation.
+    #[inline]
+    pub fn try_from_slice(slice: &[A::Item]) -> Result<Self, Error>
+    where
+        A::Item: Clone,
+    {
+        Self::try_from(smallvec::SmallVec::from_iter(slice.iter().cloned()))
+    }
+
+    /// Returns slice representation of the vector.
+    #[inline]
+    pub fn as_slice(&self) -> &[A::Item] {
+        &self.0
+    }
+
+    /// Converts into the inner unconfined vector.
+    #[inline]
+    pub fn into_smallvec(self) -> smallvec::SmallVec<A> {
+        self.0
+    }
+
+    /// Gets the mutable element of a vector
+    #[inline]
+    pub fn get_mut<I>(&mut self, index: I) -> Option<&mut I::Output>
+    where
+        I: SliceIndex<[A::Item]>,
+    {
+        self.0.get_mut(index)
+    }
+}
+
+#[cfg(feature = "smallvec")]
+impl<A: smallvec::Array, const MAX_LEN: usize> Confined<smallvec::SmallVec<A>, ZERO, MAX_LEN> {
+    /// Removes the last element from a vector and returns it, or [`None`] if it
+    /// is empty.
+    #[inline]
+    pub fn pop(&mut self) -> Option<A::Item> {
+        self.0.pop()
+    }
+}
+
+#[cfg(feature = "smallvec")]
+impl<A: smallvec::Array, const MIN_LEN: usize, const MAX_LEN: usize>
+    Confined<smallvec::SmallVec<A>, MIN_LEN, MAX_LEN>
+{
+    /// Removes an element from the vector at a given index. Errors if the index
+    /// exceeds the number of elements in the vector, of if the new vector
+    /// length will be less than the confinement requirement. Returns the
+    /// removed element otherwise.
+    pub fn remove(&mut self, index: usize) -> Result<A::Item, Error> {
+        self.check_undersize()?;
+        self.check_boundary(index)?;
+        Ok(self.0.remove(index))
+    }
+
+    /// Returns an iterator over the slice.
+    ///
+    /// The iterator yields all items from start to end.
+    pub fn iter(&self) -> core::slice::Iter<'_, A::Item> {
+        self.0.iter()
+    }
+}
+
 impl<T, const MIN_LEN: usize, const MAX_LEN: usize> Confined<VecDeque<T>, MIN_LEN, MAX_LEN> {
     /// Removes the first element and returns it, or `None` if the deque is
     /// empty.
@@ -1743,6 +1848,26 @@ pub type ConfinedIndexMap<K, V, const MIN: usize = 0, const MAX: usize = U64> =
 pub type NonEmptyIndexMap<K, V, const MAX: usize = U64> =
     Confined<indexmap::IndexMap<K, V>, ONE, MAX>;
 
+/// [`smallvec::SmallVec`] with maximum 255 items.
+#[cfg(feature = "smallvec")]
+pub type TinySmallVec<A> = Confined<smallvec::SmallVec<A>, ZERO, U8>;
+/// [`smallvec::SmallVec`] with maximum 2^16-1 items.
+#[cfg(feature = "smallvec")]
+pub type SmallSmallVec<A> = Confined<smallvec::SmallVec<A>, ZERO, U16>;
+/// [`smallvec::SmallVec`] with maximum 2^24-1 items.
+#[cfg(feature = "smallvec")]
+pub type MediumSmallVec<A> = Confined<smallvec::SmallVec<A>, ZERO, U24>;
+/// [`smallvec::SmallVec`] with maximum 2^32-1 items.
+#[cfg(feature = "smallvec")]
+pub type LargeSmallVec<A> = Confined<smallvec::SmallVec<A>, ZERO, U32>;
+#[cfg(feature = "smallvec")]
+/// Confined [`smallvec::SmallVec`].
+pub type ConfinedSmallVec<A, const MIN: usize = 0, const MAX: usize = U64> =
+    Confined<smallvec::SmallVec<A>, MIN, MAX>;
+/// [`smallvec::SmallVec`] which contains at least a single item.
+#[cfg(feature = "smallvec")]
+pub type NonEmptySmallVec<A, const MAX: usize = U64> = Confined<smallvec::SmallVec<A>, ONE, MAX>;
+
 /// Helper macro to construct confined string
 #[macro_export]
 #[deprecated(since = "4.7.0", note = "use size-specific macros")]
@@ -2209,6 +2334,48 @@ macro_rules! medium_iset {
     )
 }
 
+/// Helper macro to construct confined [`smallvec::SmallVec`] of a
+/// [`TinySmallVec`] type
+#[macro_export]
+#[cfg(feature = "smallvec")]
+macro_rules! tiny_svec {
+    () => {
+        $crate::confinement::TinySmallVec::new()
+    };
+    ($($x:expr),+ $(,)?) => (
+        $crate::confinement::TinySmallVec::try_from($crate::confinement::smallvec::SmallVec::from_iter([$($x,)+]))
+            .expect("inline tiny_svec literal contains invalid number of items")
+    )
+}
+
+/// Helper macro to construct confined [`smallvec::SmallVec`] of a
+/// [`SmallSmallVec`] type
+#[macro_export]
+#[cfg(feature = "smallvec")]
+macro_rules! small_svec {
+    () => {
+        $crate::confinement::SmallSmallVec::new()
+    };
+    ($($x:expr),+ $(,)?) => (
+        $crate::confinement::SmallSmallVec::try_from($crate::confinement::smallvec::SmallVec::from_iter([$($x,)+]))
+            .expect("inline small_svec literal contains invalid number of items")
+    )
+}
+
+/// Helper macro to construct confined [`smallvec::SmallVec`] of a
+/// [`MediumSmallVec`] type
+#[macro_export]
+#[cfg(feature = "smallvec")]
+macro_rules! medium_svec {
+    () => {
+        $crate::confinement::MediumSmallVec::new()
+    };
+    ($($x:expr),+ $(,)?) => (
+        $crate::confinement::MediumSmallVec::try_from($crate::confinement::smallvec::SmallVec::from_iter([$($x,)+]))
+            .expect("inline medium_svec literal contains invalid number of items")
+    )
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -2228,6 +2395,8 @@ mod test {
         let mut deque = TinyDeque::new();
         let mut set = TinyHashSet::new();
         let mut bset = TinyOrdSet::new();
+        #[cfg(feature = "smallvec")]
+        let mut svec = TinySmallVec::<[u8; 8]>::new();
         let mut map = TinyHashMap::new();
         let mut bmap = TinyOrdMap::new();
         #[cfg(feature = "indexmap")]
@@ -2249,6 +2418,8 @@ mod test {
             deque.push(5u8).unwrap();
             set.push(index).unwrap();
             bset.push(5u8).unwrap();
+            #[cfg(feature = "smallvec")]
+            svec.push(5u8).unwrap();
             map.insert(5u8, 'a').unwrap();
             bmap.insert(index, 'a').unwrap();
             #[cfg(feature = "indexmap")]
@@ -2260,6 +2431,8 @@ mod test {
         assert_eq!(deque.len_u8(), u8::MAX);
         assert_eq!(set.len_u8(), u8::MAX);
         assert_eq!(bset.len_u8(), 1);
+        #[cfg(feature = "smallvec")]
+        assert_eq!(svec.len_u8(), 255);
         assert_eq!(map.len_u8(), 1);
         assert_eq!(bmap.len_u8(), u8::MAX);
         #[cfg(feature = "indexmap")]
@@ -2403,6 +2576,15 @@ mod test {
             map.remove(&1),
             Err(Error::Undersize { len: 1, min_len: 1 })
         ));
+
+        #[cfg(feature = "smallvec")]
+        {
+            let mut v = NonEmptySmallVec::<[u8; 1]>::with(1);
+            assert!(matches!(
+                v.remove(0),
+                Err(Error::Undersize { len: 1, min_len: 1 })
+            ));
+        }
     }
 
     #[test]
@@ -2428,6 +2610,12 @@ mod test {
         tiny_vec!() as TinyVec<&str>;
         tiny_vec!("a", "b", "c");
         small_vec!("a", "b", "c");
+        #[cfg(feature = "smallvec")]
+        {
+            tiny_svec!() as TinySmallVec<[&str; 3]>;
+            tiny_svec!("a", "b", "c") as TinySmallVec<[&str; 3]>;
+            small_svec!("a", "b", "c") as SmallSmallVec<[&str; 3]>;
+        }
 
         tiny_set!() as TinyHashSet<&str>;
         tiny_set!("a", "b", "c");

--- a/src/collection/confinement.rs
+++ b/src/collection/confinement.rs
@@ -961,6 +961,13 @@ impl<C: Collection, const MIN_LEN: usize, const MAX_LEN: usize> Confined<C, MIN_
     }
 }
 
+impl<C: Collection, const MAX_LEN: usize> Confined<C, ZERO, MAX_LEN> {
+    /// Removes all elements from the confined collection.
+    pub fn clear(&mut self) {
+        self.0.clear()
+    }
+}
+
 impl<C: Collection, const MAX_LEN: usize> Confined<C, ZERO, MAX_LEN>
 where
     C: Default,
@@ -974,11 +981,6 @@ where
     /// pre-allocated storage for the `capacity` of elements.
     pub fn with_capacity(capacity: usize) -> Self {
         Self(C::with_capacity(capacity))
-    }
-
-    /// Removes all elements from the confined collection.
-    pub fn clear(&mut self) {
-        self.0.clear()
     }
 }
 

--- a/src/collection/confinement.rs
+++ b/src/collection/confinement.rs
@@ -122,19 +122,19 @@ impl Collection for String {
     type Item = char;
 
     fn with_capacity(capacity: usize) -> Self {
-        Self::with_capacity(capacity)
+        String::with_capacity(capacity)
     }
 
     fn len(&self) -> usize {
-        self.len()
+        String::len(self)
     }
 
     fn push(&mut self, elem: Self::Item) {
-        self.push(elem)
+        String::push(self, elem)
     }
 
     fn clear(&mut self) {
-        self.clear()
+        String::clear(self)
     }
 }
 
@@ -142,19 +142,19 @@ impl Collection for AsciiString {
     type Item = AsciiChar;
 
     fn with_capacity(capacity: usize) -> Self {
-        Self::with_capacity(capacity)
+        AsciiString::with_capacity(capacity)
     }
 
     fn len(&self) -> usize {
-        self.len()
+        AsciiString::len(self)
     }
 
     fn push(&mut self, elem: Self::Item) {
-        self.push(elem)
+        AsciiString::push(self, elem)
     }
 
     fn clear(&mut self) {
-        self.clear()
+        AsciiString::clear(self)
     }
 }
 
@@ -162,19 +162,19 @@ impl<T> Collection for Vec<T> {
     type Item = T;
 
     fn with_capacity(capacity: usize) -> Self {
-        Self::with_capacity(capacity)
+        Vec::with_capacity(capacity)
     }
 
     fn len(&self) -> usize {
-        self.len()
+        Vec::len(self)
     }
 
     fn push(&mut self, elem: Self::Item) {
-        self.push(elem)
+        Vec::push(self, elem)
     }
 
     fn clear(&mut self) {
-        self.clear()
+        Vec::clear(self)
     }
 }
 
@@ -182,19 +182,19 @@ impl<T> Collection for VecDeque<T> {
     type Item = T;
 
     fn with_capacity(capacity: usize) -> Self {
-        Self::with_capacity(capacity)
+        VecDeque::with_capacity(capacity)
     }
 
     fn len(&self) -> usize {
-        self.len()
+        VecDeque::len(self)
     }
 
     fn push(&mut self, elem: Self::Item) {
-        self.push_back(elem)
+        VecDeque::push_back(self, elem)
     }
 
     fn clear(&mut self) {
-        self.clear()
+        VecDeque::clear(self)
     }
 }
 
@@ -203,19 +203,19 @@ impl<T: Eq + Hash> Collection for HashSet<T> {
     type Item = T;
 
     fn with_capacity(capacity: usize) -> Self {
-        Self::with_capacity(capacity)
+        HashSet::with_capacity(capacity)
     }
 
     fn len(&self) -> usize {
-        self.len()
+        HashSet::len(self)
     }
 
     fn push(&mut self, elem: Self::Item) {
-        self.insert(elem);
+        HashSet::insert(self, elem);
     }
 
     fn clear(&mut self) {
-        self.clear()
+        HashSet::clear(self)
     }
 }
 
@@ -228,15 +228,15 @@ impl<T: Ord> Collection for BTreeSet<T> {
     }
 
     fn len(&self) -> usize {
-        self.len()
+        BTreeSet::len(self)
     }
 
     fn push(&mut self, elem: Self::Item) {
-        self.insert(elem);
+        BTreeSet::insert(self, elem);
     }
 
     fn clear(&mut self) {
-        self.clear()
+        BTreeSet::clear(self)
     }
 }
 
@@ -245,11 +245,11 @@ impl<K: Eq + Hash, V> Collection for HashMap<K, V> {
     type Item = (K, V);
 
     fn with_capacity(capacity: usize) -> Self {
-        Self::with_capacity(capacity)
+        HashMap::with_capacity(capacity)
     }
 
     fn len(&self) -> usize {
-        self.len()
+        HashMap::len(self)
     }
 
     fn push(&mut self, elem: Self::Item) {
@@ -257,7 +257,7 @@ impl<K: Eq + Hash, V> Collection for HashMap<K, V> {
     }
 
     fn clear(&mut self) {
-        self.clear()
+        HashMap::clear(self)
     }
 }
 
@@ -321,7 +321,7 @@ impl<K: Ord + Hash, V> Collection for BTreeMap<K, V> {
     }
 
     fn len(&self) -> usize {
-        self.len()
+        BTreeMap::len(self)
     }
 
     fn push(&mut self, elem: Self::Item) {
@@ -329,7 +329,7 @@ impl<K: Ord + Hash, V> Collection for BTreeMap<K, V> {
     }
 
     fn clear(&mut self) {
-        self.clear()
+        BTreeMap::clear(self)
     }
 }
 
@@ -388,11 +388,11 @@ impl<T: Eq + Hash> Collection for indexmap::IndexSet<T> {
     type Item = T;
 
     fn with_capacity(capacity: usize) -> Self {
-        Self::with_capacity(capacity)
+        indexmap::IndexSet::with_capacity(capacity)
     }
 
     fn len(&self) -> usize {
-        self.len()
+        indexmap::IndexSet::len(self)
     }
 
     fn push(&mut self, elem: Self::Item) {
@@ -400,7 +400,7 @@ impl<T: Eq + Hash> Collection for indexmap::IndexSet<T> {
     }
 
     fn clear(&mut self) {
-        self.clear()
+        indexmap::IndexSetclear(self)
     }
 }
 
@@ -409,11 +409,11 @@ impl<K: Eq + Hash, V> Collection for indexmap::IndexMap<K, V> {
     type Item = (K, V);
 
     fn with_capacity(capacity: usize) -> Self {
-        Self::with_capacity(capacity)
+        indexmap::IndexMap::with_capacity(capacity)
     }
 
     fn len(&self) -> usize {
-        self.len()
+        indexmap::IndexMap::len(self)
     }
 
     fn push(&mut self, elem: Self::Item) {
@@ -421,7 +421,7 @@ impl<K: Eq + Hash, V> Collection for indexmap::IndexMap<K, V> {
     }
 
     fn clear(&mut self) {
-        self.clear()
+        indexmap::IndexMap::clear(self)
     }
 }
 

--- a/src/collection/confinement.rs
+++ b/src/collection/confinement.rs
@@ -1066,7 +1066,8 @@ impl<C: KeyedCollection, const MIN_LEN: usize, const MAX_LEN: usize> Confined<C,
     /// Inserts a new value into the confined collection under a given key.
     ///
     /// If the key is already present, the value is overwritten and the previous
-    /// value is returned. This succeeds even when the collection is at capacity.
+    /// value is returned. This succeeds even when the collection is at
+    /// capacity.
     ///
     /// # Errors
     ///

--- a/src/collection/confinement.rs
+++ b/src/collection/confinement.rs
@@ -915,7 +915,7 @@ impl<C: Collection, const MIN_LEN: usize, const MAX_LEN: usize> Confined<C, MIN_
         let len = self.len();
         if len <= MIN_LEN {
             return Err(Error::Undersize {
-                len: len.saturating_sub(1),
+                len,
                 min_len: MIN_LEN,
             });
         }
@@ -926,7 +926,7 @@ impl<C: Collection, const MIN_LEN: usize, const MAX_LEN: usize> Confined<C, MIN_
         let len = self.len();
         if len >= MAX_LEN {
             return Err(Error::Oversize {
-                len: len.saturating_add(1),
+                len,
                 max_len: MAX_LEN,
             });
         }
@@ -1656,9 +1656,12 @@ impl<K: Eq + Hash, V, const MIN_LEN: usize, const MAX_LEN: usize>
 #[cfg(feature = "std")]
 impl<const MAX_LEN: usize> io::Write for Confined<Vec<u8>, ZERO, MAX_LEN> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
         let len = self.len();
         let buf_len = buf.len();
-        if buf_len > MAX_LEN || len.saturating_add(buf_len) > MAX_LEN {
+        if buf_len > MAX_LEN || len >= MAX_LEN || len.saturating_add(buf_len) > MAX_LEN {
             return Err(io::Error::from(io::ErrorKind::OutOfMemory));
         }
         self.0.extend(buf);
@@ -2409,7 +2412,7 @@ mod test {
         assert!(matches!(
             s.push('a'),
             Err(Error::Oversize {
-                len: 256,
+                len: 255,
                 max_len: 255
             })
         ));
@@ -2421,7 +2424,7 @@ mod test {
         assert!(matches!(
             v.push(1),
             Err(Error::Oversize {
-                len: 256,
+                len: 255,
                 max_len: 255
             })
         ));
@@ -2433,14 +2436,14 @@ mod test {
         assert!(matches!(
             set.push(255),
             Err(Error::Oversize {
-                len: 256,
+                len: 255,
                 max_len: 255
             })
         ));
         assert!(matches!(
             set.push(0),
             Err(Error::Oversize {
-                len: 256,
+                len: 255,
                 max_len: 255
             })
         ));
@@ -2452,14 +2455,14 @@ mod test {
         assert!(matches!(
             map.insert(255, 0),
             Err(Error::Oversize {
-                len: 256,
+                len: 255,
                 max_len: 255
             })
         ));
         assert!(matches!(
             map.insert(0, 0),
             Err(Error::Oversize {
-                len: 256,
+                len: 255,
                 max_len: 255
             })
         ));
@@ -2512,25 +2515,25 @@ mod test {
         let mut s = NonEmptyString::<U8>::with('a');
         assert!(matches!(
             s.remove(0),
-            Err(Error::Undersize { len: 0, min_len: 1 })
+            Err(Error::Undersize { len: 1, min_len: 1 })
         ));
 
         let mut v = NonEmptyVec::<u8>::with(1);
         assert!(matches!(
             v.remove(0),
-            Err(Error::Undersize { len: 0, min_len: 1 })
+            Err(Error::Undersize { len: 1, min_len: 1 })
         ));
 
         let mut set = NonEmptyOrdSet::<u8>::with(1);
         assert!(matches!(
             set.remove(&1),
-            Err(Error::Undersize { len: 0, min_len: 1 })
+            Err(Error::Undersize { len: 1, min_len: 1 })
         ));
 
         let mut map = NonEmptyOrdMap::<u8, u8>::with_key_value(1, 1);
         assert!(matches!(
             map.remove(&1),
-            Err(Error::Undersize { len: 0, min_len: 1 })
+            Err(Error::Undersize { len: 1, min_len: 1 })
         ));
     }
 

--- a/src/collection/confinement.rs
+++ b/src/collection/confinement.rs
@@ -994,6 +994,21 @@ where
     }
 }
 
+impl<C, const MAX_LEN: usize> Confined<C, ONE, MAX_LEN>
+where
+    C: Collection + Index<usize, Output = C::Item>,
+{
+    /// Returns the first element.
+    pub fn first(&self) -> &C::Item {
+        self.0.index(0)
+    }
+
+    /// Returns the last element.
+    pub fn last(&self) -> &C::Item {
+        self.0.index(self.len() - 1)
+    }
+}
+
 impl<C: Collection, const MIN_LEN: usize> Confined<C, MIN_LEN, U8>
 where
     C: Default,
@@ -2217,5 +2232,19 @@ mod test {
         assert_eq!(coll.get(&1), Some(&"four"));
         *coll.get_mut(&1).unwrap() = "five";
         assert_eq!(coll.get(&1), Some(&"five"));
+    }
+
+    #[test]
+    fn first_last_non_empty_vec() {
+        let coll = NonEmptyVec::<u8, U8>::try_from(vec![1, 2, 3]).unwrap();
+        assert_eq!(*coll.first(), 1);
+        assert_eq!(*coll.last(), 3);
+    }
+
+    #[test]
+    fn first_last_non_empty_deque() {
+        let coll = NonEmptyDeque::<u8, U8>::try_from_iter([1, 2, 3]).unwrap();
+        assert_eq!(*coll.first(), 1);
+        assert_eq!(*coll.last(), 3);
     }
 }

--- a/src/collection/confinement.rs
+++ b/src/collection/confinement.rs
@@ -31,9 +31,11 @@ use core::slice::SliceIndex;
 use core::ops::RangeBounds;
 #[cfg(feature = "std")]
 use std::{
-    io,
     collections::{hash_map, HashMap, HashSet},
+    io,
 };
+#[cfg(feature = "indexmap")]
+pub use indexmap_crate as indexmap;
 use amplify_num::hex;
 use amplify_num::hex::{FromHex, ToHex};
 use ascii::{AsAsciiStrError, AsciiChar, AsciiString};
@@ -378,6 +380,78 @@ impl<K: Ord + Hash, V> KeyedCollection for BTreeMap<K, V> {
 
     fn retain(&mut self, f: impl FnMut(&K, &mut V) -> bool) {
         BTreeMap::retain(self, f)
+    }
+}
+
+#[cfg(feature = "indexmap")]
+impl<K: Eq + Hash, V> Collection for indexmap::IndexMap<K, V> {
+    type Item = (K, V);
+
+    fn with_capacity(capacity: usize) -> Self {
+        Self::with_capacity(capacity)
+    }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn push(&mut self, elem: Self::Item) {
+        indexmap::IndexMap::insert(self, elem.0, elem.1);
+    }
+
+    fn clear(&mut self) {
+        self.clear()
+    }
+}
+
+#[cfg(feature = "indexmap")]
+impl<K: Eq + Hash, V> KeyedCollection for indexmap::IndexMap<K, V> {
+    type Key = K;
+    type Value = V;
+    type Entry<'a>
+        = indexmap::map::Entry<'a, K, V>
+    where
+        K: 'a,
+        V: 'a;
+
+    fn contains_key(&self, key: &Self::Key) -> bool {
+        indexmap::IndexMap::contains_key(self, key)
+    }
+
+    fn get(&self, key: &Self::Key) -> Option<&Self::Value> {
+        indexmap::IndexMap::get(self, key)
+    }
+
+    fn get_mut(&mut self, key: &Self::Key) -> Option<&mut Self::Value> {
+        indexmap::IndexMap::get_mut(self, key)
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (&Self::Key, &Self::Value)> {
+        indexmap::IndexMap::iter(self)
+    }
+
+    fn iter_mut(&mut self) -> impl Iterator<Item = (&Self::Key, &mut Self::Value)> {
+        indexmap::IndexMap::iter_mut(self)
+    }
+
+    fn values_mut(&mut self) -> impl Iterator<Item = &mut Self::Value> {
+        indexmap::IndexMap::values_mut(self)
+    }
+
+    fn insert(&mut self, key: Self::Key, value: Self::Value) -> Option<Self::Value> {
+        indexmap::IndexMap::insert(self, key, value)
+    }
+
+    fn remove(&mut self, key: &Self::Key) -> Option<Self::Value> {
+        indexmap::IndexMap::shift_remove(self, key)
+    }
+
+    fn entry(&mut self, key: Self::Key) -> Self::Entry<'_> {
+        indexmap::IndexMap::entry(self, key)
+    }
+
+    fn retain(&mut self, f: impl FnMut(&K, &mut V) -> bool) {
+        indexmap::IndexMap::retain(self, f)
     }
 }
 
@@ -1555,6 +1629,42 @@ impl<K: Ord + Hash, V, const MIN_LEN: usize, const MAX_LEN: usize>
     }
 }
 
+#[cfg(feature = "indexmap")]
+impl<K: Eq + Hash, V, const MIN_LEN: usize, const MAX_LEN: usize>
+    Confined<indexmap::IndexMap<K, V>, MIN_LEN, MAX_LEN>
+{
+    /// Removes a key from the map, returning the value at the key if the key
+    /// was previously in the map.
+    ///
+    /// # Errors
+    ///
+    /// Errors if the minimum confinement is not met after the removal.
+    pub fn remove(&mut self, key: &K) -> Result<Option<V>, Error> {
+        let len = self.0.len();
+        if len == MIN_LEN || len - 1 < MIN_LEN {
+            return Err(Error::Undersize {
+                len: len - 1,
+                min_len: MIN_LEN,
+            });
+        }
+        Ok(self.0.shift_remove(key))
+    }
+
+    /// Creates a consuming iterator visiting all the keys in arbitrary order.
+    /// The map cannot be used after calling this. The iterator element type is
+    /// `K`.
+    pub fn into_keys(self) -> indexmap::map::IntoKeys<K, V> {
+        self.0.into_keys()
+    }
+
+    /// Creates a consuming iterator visiting all the values in arbitrary order.
+    /// The map cannot be used after calling this. The iterator element type is
+    /// `V`.
+    pub fn into_values(self) -> indexmap::map::IntoValues<K, V> {
+        self.0.into_values()
+    }
+}
+
 // io::Writer
 #[cfg(feature = "std")]
 impl<const MAX_LEN: usize> io::Write for Confined<Vec<u8>, ZERO, MAX_LEN> {
@@ -1731,6 +1841,27 @@ pub type ConfinedOrdMap<K, V, const MIN: usize = 0, const MAX: usize = U64> =
     Confined<BTreeMap<K, V>, MIN, MAX>;
 /// [`BTreeMap`] which contains at least a single item.
 pub type NonEmptyOrdMap<K, V, const MAX: usize = U64> = Confined<BTreeMap<K, V>, ONE, MAX>;
+
+/// [`indexmap::IndexMap`] with maximum 255 items.
+#[cfg(feature = "indexmap")]
+pub type TinyIndexMap<K, V> = Confined<indexmap::IndexMap<K, V>, ZERO, U8>;
+/// [`indexmap::IndexMap`] with maximum 2^16-1 items.
+#[cfg(feature = "indexmap")]
+pub type SmallIndexMap<K, V> = Confined<indexmap::IndexMap<K, V>, ZERO, U16>;
+/// [`indexmap::IndexMap`] with maximum 2^24-1 items.
+#[cfg(feature = "indexmap")]
+pub type MediumIndexMap<K, V> = Confined<indexmap::IndexMap<K, V>, ZERO, U24>;
+/// [`indexmap::IndexMap`] with maximum 2^32-1 items.
+#[cfg(feature = "indexmap")]
+pub type LargeIndexMap<K, V> = Confined<indexmap::IndexMap<K, V>, ZERO, U32>;
+#[cfg(feature = "indexmap")]
+/// Confined [`indexmap::IndexMap`].
+pub type ConfinedIndexMap<K, V, const MIN: usize = 0, const MAX: usize = U64> =
+    Confined<indexmap::IndexMap<K, V>, MIN, MAX>;
+/// [`indexmap::IndexMap`] which contains at least a single item.
+#[cfg(feature = "indexmap")]
+pub type NonEmptyIndexMap<K, V, const MAX: usize = U64> =
+    Confined<indexmap::IndexMap<K, V>, ONE, MAX>;
 
 /// Helper macro to construct confined string
 #[macro_export]
@@ -2114,6 +2245,48 @@ macro_rules! medium_bmap {
     }
 }
 
+/// Helper macro to construct confined [`indexmap::IndexMap`] of a
+/// [`TinyIndexMap`] type
+#[macro_export]
+#[cfg(feature = "indexmap")]
+macro_rules! tiny_imap {
+    () => {
+        $crate::confinement::TinyIndexMap::new()
+    };
+    { $($key:expr => $value:expr),+ $(,)? } => {
+        $crate::confinement::TinyIndexMap::try_from($crate::confinement::indexmap::IndexMap::from_iter([$(($key, $value)),+]))
+            .expect("inline tiny_imap literal contains invalid number of items")
+    }
+}
+
+/// Helper macro to construct confined [`indexmap::IndexMap`] of a
+/// [`SmallIndexMap`] type
+#[macro_export]
+#[cfg(feature = "indexmap")]
+macro_rules! small_imap {
+    () => {
+        $crate::confinement::SmallIndexMap::new()
+    };
+    { $($key:expr => $value:expr),+ $(,)? } => {
+        $crate::confinement::SmallIndexMap::try_from($crate::confinement::indexmap::IndexMap::from_iter([$(($key, $value)),+]))
+            .expect("inline small_imap literal contains invalid number of items")
+    }
+}
+
+/// Helper macro to construct confined [`indexmap::IndexMap`] of a
+/// [`MediumIndexMap`] type
+#[macro_export]
+#[cfg(feature = "indexmap")]
+macro_rules! medium_imap {
+    () => {
+        $crate::confinement::MediumIndexMap::new()
+    };
+    { $($key:expr => $value:expr),+ $(,)? } => {
+        $crate::confinement::MediumIndexMap::try_from($crate::confinement::indexmap::IndexMap::from_iter([$(($key, $value)),+]))
+            .expect("inline medium_imap literal contains invalid number of items")
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -2218,6 +2391,26 @@ mod test {
     #[test]
     fn iter_mut_btree() {
         let mut coll = tiny_bmap!(1 => "one");
+        for (_index, item) in &mut coll {
+            *item = "two";
+        }
+        assert_eq!(coll.get(&1), Some(&"two"));
+        for (_index, item) in coll.keyed_values_mut() {
+            *item = "three";
+        }
+        assert_eq!(coll.get(&1), Some(&"three"));
+        for item in coll.values_mut() {
+            *item = "four";
+        }
+        assert_eq!(coll.get(&1), Some(&"four"));
+        *coll.get_mut(&1).unwrap() = "five";
+        assert_eq!(coll.get(&1), Some(&"five"));
+    }
+
+    #[test]
+    #[cfg(feature = "indexmap")]
+    fn iter_mut_indexmap() {
+        let mut coll = tiny_imap!(1 => "one");
         for (_index, item) in &mut coll {
             *item = "two";
         }

--- a/src/collection/confinement.rs
+++ b/src/collection/confinement.rs
@@ -1067,7 +1067,9 @@ impl<C: KeyedCollection, const MIN_LEN: usize, const MAX_LEN: usize> Confined<C,
     /// Fails if the collection already contains the maximum number of elements
     /// allowed by the confinement.
     pub fn insert(&mut self, key: C::Key, value: C::Value) -> Result<Option<C::Value>, Error> {
-        self.check_oversize()?;
+        if !self.0.contains_key(&key) {
+            self.check_oversize()?;
+        }
         Ok(self.0.insert(key, value))
     }
 

--- a/src/collection/confinement.rs
+++ b/src/collection/confinement.rs
@@ -384,6 +384,27 @@ impl<K: Ord + Hash, V> KeyedCollection for BTreeMap<K, V> {
 }
 
 #[cfg(feature = "indexmap")]
+impl<T: Eq + Hash> Collection for indexmap::IndexSet<T> {
+    type Item = T;
+
+    fn with_capacity(capacity: usize) -> Self {
+        Self::with_capacity(capacity)
+    }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn push(&mut self, elem: Self::Item) {
+        indexmap::IndexSet::insert(self, elem);
+    }
+
+    fn clear(&mut self) {
+        self.clear()
+    }
+}
+
+#[cfg(feature = "indexmap")]
 impl<K: Eq + Hash, V> Collection for indexmap::IndexMap<K, V> {
     type Item = (K, V);
 
@@ -1131,6 +1152,45 @@ where
     }
 }
 
+#[cfg(feature = "indexmap")]
+impl<T: Eq + Hash, const MIN_LEN: usize, const MAX_LEN: usize>
+    Confined<indexmap::IndexSet<T>, MIN_LEN, MAX_LEN>
+{
+    /// Removes a value from the set, returning whether the value was at the
+    /// set previously.
+    ///
+    /// # Errors
+    ///
+    /// Errors if the minimum confinement is not met after the removal.
+    pub fn remove(&mut self, elem: &T) -> Result<bool, Error> {
+        let len = self.0.len();
+        if len == MIN_LEN || len - 1 < MIN_LEN {
+            return Err(Error::Undersize {
+                len: len - 1,
+                min_len: MIN_LEN,
+            });
+        }
+        Ok(self.0.shift_remove(elem))
+    }
+
+    /// Removes and returns the value in the set, if any, that is equal to the
+    /// given one.
+    ///
+    /// # Errors
+    ///
+    /// Errors if the minimum confinement is not met after the removal.
+    pub fn take(&mut self, elem: &T) -> Result<Option<T>, Error> {
+        let len = self.0.len();
+        if len == MIN_LEN || len - 1 < MIN_LEN {
+            return Err(Error::Undersize {
+                len: len - 1,
+                min_len: MIN_LEN,
+            });
+        }
+        Ok(self.0.shift_take(elem))
+    }
+}
+
 impl<C: KeyedCollection, const MIN_LEN: usize, const MAX_LEN: usize> Confined<C, MIN_LEN, MAX_LEN> {
     /// Gets mutable reference to an element of the collection.
     pub fn get_mut(&mut self, key: &C::Key) -> Option<&mut C::Value> {
@@ -1842,6 +1902,26 @@ pub type ConfinedOrdMap<K, V, const MIN: usize = 0, const MAX: usize = U64> =
 /// [`BTreeMap`] which contains at least a single item.
 pub type NonEmptyOrdMap<K, V, const MAX: usize = U64> = Confined<BTreeMap<K, V>, ONE, MAX>;
 
+/// [`indexmap::IndexSet`] with maximum 255 items of type `T`.
+#[cfg(feature = "indexmap")]
+pub type TinyIndexSet<T> = Confined<indexmap::IndexSet<T>, ZERO, U8>;
+/// [`indexmap::IndexSet`] with maximum 2^16-1 items of type `T`.
+#[cfg(feature = "indexmap")]
+pub type SmallIndexSet<T> = Confined<indexmap::IndexSet<T>, ZERO, U16>;
+/// [`indexmap::IndexSet`] with maximum 2^24-1 items of type `T`.
+#[cfg(feature = "indexmap")]
+pub type MediumIndexSet<T> = Confined<indexmap::IndexSet<T>, ZERO, U24>;
+/// [`indexmap::IndexSet`] with maximum 2^32-1 items of type `T`.
+#[cfg(feature = "indexmap")]
+pub type LargeIndexSet<T> = Confined<indexmap::IndexSet<T>, ZERO, U32>;
+#[cfg(feature = "indexmap")]
+/// Confined [`indexmap::IndexSet`].
+pub type ConfinedIndexSet<T, const MIN: usize = 0, const MAX: usize = U64> =
+    Confined<indexmap::IndexSet<T>, MIN, MAX>;
+/// [`indexmap::IndexSet`] which contains at least a single item.
+#[cfg(feature = "indexmap")]
+pub type NonEmptyIndexSet<T, const MAX: usize = U64> = Confined<indexmap::IndexSet<T>, ONE, MAX>;
+
 /// [`indexmap::IndexMap`] with maximum 255 items.
 #[cfg(feature = "indexmap")]
 pub type TinyIndexMap<K, V> = Confined<indexmap::IndexMap<K, V>, ZERO, U8>;
@@ -2287,6 +2367,48 @@ macro_rules! medium_imap {
     }
 }
 
+/// Helper macro to construct confined [`indexmap::IndexSet`] of a
+/// [`TinyIndexSet`] type
+#[macro_export]
+#[cfg(feature = "indexmap")]
+macro_rules! tiny_iset {
+    () => {
+        $crate::confinement::TinyIndexSet::new()
+    };
+    ($($x:expr),+ $(,)?) => (
+        $crate::confinement::TinyIndexSet::try_from($crate::confinement::indexmap::IndexSet::from_iter([$($x,)+]))
+            .expect("inline tiny_iset literal contains invalid number of items")
+    )
+}
+
+/// Helper macro to construct confined [`indexmap::IndexSet`] of a
+/// [`SmallIndexSet`] type
+#[macro_export]
+#[cfg(feature = "indexmap")]
+macro_rules! small_iset {
+    () => {
+        $crate::confinement::SmallIndexSet::new()
+    };
+    ($($x:expr),+ $(,)?) => (
+        $crate::confinement::SmallIndexSet::try_from($crate::confinement::indexmap::IndexSet::from_iter([$($x,)+]))
+            .expect("inline small_iset literal contains invalid number of items")
+    )
+}
+
+/// Helper macro to construct confined [`indexmap::IndexSet`] of a
+/// [`MediumIndexSet`] type
+#[macro_export]
+#[cfg(feature = "indexmap")]
+macro_rules! medium_iset {
+    () => {
+        $crate::confinement::MediumIndexSet::new()
+    };
+    ($($x:expr),+ $(,)?) => (
+        $crate::confinement::MediumIndexSet::try_from($crate::confinement::indexmap::IndexSet::from_iter([$($x,)+]))
+            .expect("inline medium_iset literal contains invalid number of items")
+    )
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -2308,12 +2430,20 @@ mod test {
         let mut bset = TinyOrdSet::new();
         let mut map = TinyHashMap::new();
         let mut bmap = TinyOrdMap::new();
+        #[cfg(feature = "indexmap")]
+        let mut imap = TinyIndexMap::new();
+        #[cfg(feature = "indexmap")]
+        let mut iset = TinyIndexSet::new();
         assert!(vec.is_empty());
         assert!(deque.is_empty());
         assert!(set.is_empty());
         assert!(bset.is_empty());
         assert!(map.is_empty());
         assert!(bmap.is_empty());
+        #[cfg(feature = "indexmap")]
+        assert!(imap.is_empty());
+        #[cfg(feature = "indexmap")]
+        assert!(iset.is_empty());
         for index in 1..=255 {
             vec.push(5u8).unwrap();
             deque.push(5u8).unwrap();
@@ -2321,6 +2451,10 @@ mod test {
             bset.push(5u8).unwrap();
             map.insert(5u8, 'a').unwrap();
             bmap.insert(index, 'a').unwrap();
+            #[cfg(feature = "indexmap")]
+            imap.insert(index, 'a').unwrap();
+            #[cfg(feature = "indexmap")]
+            iset.push(index).unwrap();
         }
         assert_eq!(vec.len_u8(), u8::MAX);
         assert_eq!(deque.len_u8(), u8::MAX);
@@ -2328,6 +2462,10 @@ mod test {
         assert_eq!(bset.len_u8(), 1);
         assert_eq!(map.len_u8(), 1);
         assert_eq!(bmap.len_u8(), u8::MAX);
+        #[cfg(feature = "indexmap")]
+        assert_eq!(imap.len_u8(), u8::MAX);
+        #[cfg(feature = "indexmap")]
+        assert_eq!(iset.len_u8(), u8::MAX);
 
         vec.clear();
         assert!(vec.is_empty());
@@ -2386,6 +2524,17 @@ mod test {
         small_bset!("a", "b", "c");
         small_map!("a" => 1, "b" => 2, "c" => 3);
         small_bmap!("a" => 1, "b" => 2, "c" => 3);
+
+        #[cfg(feature = "indexmap")]
+        {
+            tiny_imap!() as TinyIndexMap<&str, u8>;
+            tiny_imap!("a" => 1, "b" => 2, "c" => 3);
+            small_imap!("a" => 1, "b" => 2, "c" => 3);
+
+            tiny_iset!() as TinyIndexSet<&str>;
+            tiny_iset!("a", "b", "c");
+            small_iset!("a", "b", "c");
+        }
     }
 
     #[test]

--- a/src/collection/confinement.rs
+++ b/src/collection/confinement.rs
@@ -922,6 +922,17 @@ impl<C: Collection, const MIN_LEN: usize, const MAX_LEN: usize> Confined<C, MIN_
         Ok(())
     }
 
+    fn check_oversize(&self) -> Result<(), Error> {
+        let len = self.len();
+        if len >= MAX_LEN {
+            return Err(Error::Oversize {
+                len: len.saturating_add(1),
+                max_len: MAX_LEN,
+            });
+        }
+        Ok(())
+    }
+
     /// Constructs confinement over collection which was already size-checked.
     ///
     /// # Panics
@@ -1009,13 +1020,7 @@ impl<C: Collection, const MIN_LEN: usize, const MAX_LEN: usize> Confined<C, MIN_
     /// Attempts to add a single element to the confined collection. Fails if
     /// the number of elements in the collection already maximal.
     pub fn push(&mut self, elem: C::Item) -> Result<(), Error> {
-        let len = self.len();
-        if len == MAX_LEN || len + 1 > MAX_LEN {
-            return Err(Error::Oversize {
-                len: len + 1,
-                max_len: MAX_LEN,
-            });
-        }
+        self.check_oversize()?;
         self.0.push(elem);
         Ok(())
     }
@@ -1173,26 +1178,17 @@ impl<C: KeyedCollection, const MIN_LEN: usize, const MAX_LEN: usize> Confined<C,
     /// Fails if the collection already contains maximum number of elements
     /// allowed by the confinement.
     pub fn insert(&mut self, key: C::Key, value: C::Value) -> Result<Option<C::Value>, Error> {
-        let len = self.len();
-        if len == MAX_LEN || len + 1 > MAX_LEN {
-            return Err(Error::Oversize {
-                len: len + 1,
-                max_len: MAX_LEN,
-            });
-        }
+        self.check_oversize()?;
         Ok(self.0.insert(key, value))
     }
 
+    // TODO: This is strange; it doesn't need to check the bound and error!
     /// Gets the given key's corresponding entry in the map for in-place
     /// manipulation. Errors if the collection entry is vacant and the
     /// collection has already reached maximal size of its confinement.
     pub fn entry(&mut self, key: C::Key) -> Result<C::Entry<'_>, Error> {
-        let len = self.len();
-        if len == MAX_LEN && !self.0.contains_key(&key) {
-            return Err(Error::Oversize {
-                len: len + 1,
-                max_len: MAX_LEN,
-            });
+        if !self.0.contains_key(&key) {
+            self.check_oversize()?;
         }
         Ok(self.0.entry(key))
     }
@@ -1416,13 +1412,7 @@ impl<T, const MIN_LEN: usize, const MAX_LEN: usize> Confined<VecDeque<T>, MIN_LE
     /// Prepends an element to the deque. Errors if the new collection length
     /// will not fit the confinement requirements.
     pub fn push_front(&mut self, elem: T) -> Result<(), Error> {
-        let len = self.len();
-        if len == MAX_LEN || len + 1 > MAX_LEN {
-            return Err(Error::Oversize {
-                len: len + 1,
-                max_len: MAX_LEN,
-            });
-        }
+        self.check_oversize()?;
         self.0.push_front(elem);
         Ok(())
     }
@@ -1435,13 +1425,7 @@ impl<T, const MIN_LEN: usize, const MAX_LEN: usize> Confined<VecDeque<T>, MIN_LE
     /// Appends an element to the deque. Errors if the new collection length
     /// will not fit the confinement requirements.
     pub fn push_back(&mut self, elem: T) -> Result<(), Error> {
-        let len = self.len();
-        if len == MAX_LEN || len + 1 > MAX_LEN {
-            return Err(Error::Oversize {
-                len: len + 1,
-                max_len: MAX_LEN,
-            });
-        }
+        self.check_oversize()?;
         self.0.push_back(elem);
         Ok(())
     }
@@ -1676,7 +1660,9 @@ impl<K: Eq + Hash, V, const MIN_LEN: usize, const MAX_LEN: usize>
 #[cfg(feature = "std")]
 impl<const MAX_LEN: usize> io::Write for Confined<Vec<u8>, ZERO, MAX_LEN> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        if buf.len() + self.len() >= MAX_LEN {
+        let len = self.len();
+        let buf_len = buf.len();
+        if buf_len > MAX_LEN || len.saturating_add(buf_len) > MAX_LEN {
             return Err(io::Error::from(io::ErrorKind::OutOfMemory));
         }
         self.0.extend(buf);
@@ -2419,12 +2405,68 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "Oversize")]
     fn cant_go_above_max() {
         let mut s = TinyString::new();
-        for _ in 1..=256 {
+        for _ in 1..=255 {
             s.push('a').unwrap();
         }
+        assert!(matches!(
+            s.push('a'),
+            Err(Error::Oversize {
+                len: 256,
+                max_len: 255
+            })
+        ));
+
+        let mut v = TinyVec::<u8>::new();
+        for _ in 1..=255 {
+            v.push(1).unwrap();
+        }
+        assert!(matches!(
+            v.push(1),
+            Err(Error::Oversize {
+                len: 256,
+                max_len: 255
+            })
+        ));
+
+        let mut set = TinyOrdSet::<u8>::new();
+        for i in 1..=255 {
+            set.push(i).unwrap();
+        }
+        assert!(matches!(
+            set.push(255),
+            Err(Error::Oversize {
+                len: 256,
+                max_len: 255
+            })
+        ));
+        assert!(matches!(
+            set.push(0),
+            Err(Error::Oversize {
+                len: 256,
+                max_len: 255
+            })
+        ));
+
+        let mut map = TinyOrdMap::<u8, u8>::new();
+        for i in 1..=255 {
+            map.insert(i, i).unwrap();
+        }
+        assert!(matches!(
+            map.insert(255, 0),
+            Err(Error::Oversize {
+                len: 256,
+                max_len: 255
+            })
+        ));
+        assert!(matches!(
+            map.insert(0, 0),
+            Err(Error::Oversize {
+                len: 256,
+                max_len: 255
+            })
+        ));
     }
 
     #[test]

--- a/src/collection/confinement.rs
+++ b/src/collection/confinement.rs
@@ -400,7 +400,7 @@ impl<T: Eq + Hash> Collection for indexmap::IndexSet<T> {
     }
 
     fn clear(&mut self) {
-        indexmap::IndexSetclear(self)
+        indexmap::IndexSet::clear(self)
     }
 }
 
@@ -481,7 +481,7 @@ impl<K: Eq + Hash, V> KeyedCollection for indexmap::IndexMap<K, V> {
 /// Errors when confinement constraints were not met.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum Error {
-    /// Operation results in collection reduced below the required minimum
+    /// Operation results in a collection reduced below the required minimum
     /// number of elements.
     Undersize {
         /** Current collection length */
@@ -491,8 +491,8 @@ pub enum Error {
         min_len: usize,
     },
 
-    /// Operation results in collection growth above the required maximum number
-    /// of elements.
+    /// Operation results in a collection growth above the required maximum
+    /// number of elements.
     Oversize {
         /** Current collection length */
         len: usize,
@@ -911,6 +911,17 @@ impl<C: Collection, const MIN_LEN: usize, const MAX_LEN: usize> Confined<C, MIN_
         Ok(())
     }
 
+    fn check_undersize(&self) -> Result<(), Error> {
+        let len = self.len();
+        if len <= MIN_LEN {
+            return Err(Error::Undersize {
+                len: len.saturating_sub(1),
+                min_len: MIN_LEN,
+            });
+        }
+        Ok(())
+    }
+
     /// Constructs confinement over collection which was already size-checked.
     ///
     /// # Panics
@@ -1152,45 +1163,6 @@ where
     }
 }
 
-#[cfg(feature = "indexmap")]
-impl<T: Eq + Hash, const MIN_LEN: usize, const MAX_LEN: usize>
-    Confined<indexmap::IndexSet<T>, MIN_LEN, MAX_LEN>
-{
-    /// Removes a value from the set, returning whether the value was at the
-    /// set previously.
-    ///
-    /// # Errors
-    ///
-    /// Errors if the minimum confinement is not met after the removal.
-    pub fn remove(&mut self, elem: &T) -> Result<bool, Error> {
-        let len = self.0.len();
-        if len == MIN_LEN || len - 1 < MIN_LEN {
-            return Err(Error::Undersize {
-                len: len - 1,
-                min_len: MIN_LEN,
-            });
-        }
-        Ok(self.0.shift_remove(elem))
-    }
-
-    /// Removes and returns the value in the set, if any, that is equal to the
-    /// given one.
-    ///
-    /// # Errors
-    ///
-    /// Errors if the minimum confinement is not met after the removal.
-    pub fn take(&mut self, elem: &T) -> Result<Option<T>, Error> {
-        let len = self.0.len();
-        if len == MIN_LEN || len - 1 < MIN_LEN {
-            return Err(Error::Undersize {
-                len: len - 1,
-                min_len: MIN_LEN,
-            });
-        }
-        Ok(self.0.shift_take(elem))
-    }
-}
-
 impl<C: KeyedCollection, const MIN_LEN: usize, const MAX_LEN: usize> Confined<C, MIN_LEN, MAX_LEN> {
     /// Gets mutable reference to an element of the collection.
     pub fn get_mut(&mut self, key: &C::Key) -> Option<&mut C::Value> {
@@ -1239,9 +1211,10 @@ impl<C: KeyedCollection, const MIN_LEN: usize, const MAX_LEN: usize> Confined<C,
         f: impl FnMut(&C::Key, &mut C::Value) -> bool,
     ) -> Result<(), Error> {
         self.0.retain(f);
-        if self.0.len() < MIN_LEN {
+        let len = self.len();
+        if len < MIN_LEN {
             return Err(Error::Undersize {
-                len: self.0.len(),
+                len,
                 min_len: MIN_LEN,
             });
         }
@@ -1307,13 +1280,8 @@ impl<const MIN_LEN: usize, const MAX_LEN: usize> Confined<String, MIN_LEN, MAX_L
     /// doesn't shorten more than the confinement requirement. Errors
     /// otherwise.
     pub fn remove(&mut self, index: usize) -> Result<char, Error> {
+        self.check_undersize()?;
         let len = self.len();
-        if self.is_empty() || len <= MIN_LEN {
-            return Err(Error::Undersize {
-                len,
-                min_len: MIN_LEN,
-            });
-        }
         if index >= len {
             return Err(Error::OutOfBoundary { index, len });
         }
@@ -1334,13 +1302,8 @@ impl<const MIN_LEN: usize, const MAX_LEN: usize> Confined<AsciiString, MIN_LEN, 
     /// doesn't shorten more than the confinement requirement. Errors
     /// otherwise.
     pub fn remove(&mut self, index: usize) -> Result<AsciiChar, Error> {
+        self.check_undersize()?;
         let len = self.len();
-        if self.is_empty() || len <= MIN_LEN {
-            return Err(Error::Undersize {
-                len,
-                min_len: MIN_LEN,
-            });
-        }
         if index >= len {
             return Err(Error::OutOfBoundary { index, len });
         }
@@ -1419,13 +1382,8 @@ impl<T, const MIN_LEN: usize, const MAX_LEN: usize> Confined<Vec<T>, MIN_LEN, MA
     /// length will be less than the confinement requirement. Returns the
     /// removed element otherwise.
     pub fn remove(&mut self, index: usize) -> Result<T, Error> {
+        self.check_undersize()?;
         let len = self.len();
-        if self.is_empty() || len <= MIN_LEN {
-            return Err(Error::Undersize {
-                len,
-                min_len: MIN_LEN,
-            });
-        }
         if index >= len {
             return Err(Error::OutOfBoundary { index, len });
         }
@@ -1493,13 +1451,8 @@ impl<T, const MIN_LEN: usize, const MAX_LEN: usize> Confined<VecDeque<T>, MIN_LE
     /// length will be less than the confinement requirement. Returns the
     /// removed element otherwise.
     pub fn remove(&mut self, index: usize) -> Result<T, Error> {
+        self.check_undersize()?;
         let len = self.len();
-        if self.is_empty() || len <= MIN_LEN {
-            return Err(Error::Undersize {
-                len,
-                min_len: MIN_LEN,
-            });
-        }
         if index >= len {
             return Err(Error::OutOfBoundary { index, len });
         }
@@ -1549,13 +1502,7 @@ impl<T: Hash + Eq, const MIN_LEN: usize, const MAX_LEN: usize>
         if !self.0.contains(elem) {
             return Ok(false);
         }
-        let len = self.len();
-        if self.is_empty() || len <= MIN_LEN {
-            return Err(Error::Undersize {
-                len,
-                min_len: MIN_LEN,
-            });
-        }
+        self.check_undersize()?;
         Ok(self.0.remove(elem))
     }
 
@@ -1567,13 +1514,7 @@ impl<T: Hash + Eq, const MIN_LEN: usize, const MAX_LEN: usize>
         if !self.0.contains(elem) {
             return Ok(None);
         }
-        let len = self.len();
-        if self.is_empty() || len <= MIN_LEN {
-            return Err(Error::Undersize {
-                len,
-                min_len: MIN_LEN,
-            });
-        }
+        self.check_undersize()?;
         Ok(self.0.take(elem))
     }
 }
@@ -1587,13 +1528,7 @@ impl<T: Ord, const MIN_LEN: usize, const MAX_LEN: usize> Confined<BTreeSet<T>, M
         if !self.0.contains(elem) {
             return Ok(false);
         }
-        let len = self.len();
-        if self.is_empty() || len <= MIN_LEN {
-            return Err(Error::Undersize {
-                len,
-                min_len: MIN_LEN,
-            });
-        }
+        self.check_undersize()?;
         Ok(self.0.remove(elem))
     }
 
@@ -1605,13 +1540,7 @@ impl<T: Ord, const MIN_LEN: usize, const MAX_LEN: usize> Confined<BTreeSet<T>, M
         if !self.0.contains(elem) {
             return Ok(None);
         }
-        let len = self.len();
-        if self.is_empty() || len - 1 <= MIN_LEN {
-            return Err(Error::Undersize {
-                len,
-                min_len: MIN_LEN,
-            });
-        }
+        self.check_undersize()?;
         Ok(self.0.take(elem))
     }
 }
@@ -1628,13 +1557,7 @@ impl<K: Hash + Eq, V, const MIN_LEN: usize, const MAX_LEN: usize>
         if !self.0.contains_key(key) {
             return Ok(None);
         }
-        let len = self.len();
-        if self.is_empty() || len <= MIN_LEN {
-            return Err(Error::Undersize {
-                len,
-                min_len: MIN_LEN,
-            });
-        }
+        self.check_undersize()?;
         Ok(self.0.remove(key))
     }
 
@@ -1664,13 +1587,7 @@ impl<K: Ord + Hash, V, const MIN_LEN: usize, const MAX_LEN: usize>
         if !self.0.contains_key(key) {
             return Ok(None);
         }
-        let len = self.len();
-        if self.is_empty() || len <= MIN_LEN {
-            return Err(Error::Undersize {
-                len,
-                min_len: MIN_LEN,
-            });
-        }
+        self.check_undersize()?;
         Ok(self.0.remove(key))
     }
 
@@ -1690,6 +1607,39 @@ impl<K: Ord + Hash, V, const MIN_LEN: usize, const MAX_LEN: usize>
 }
 
 #[cfg(feature = "indexmap")]
+impl<T: Eq + Hash, const MIN_LEN: usize, const MAX_LEN: usize>
+    Confined<indexmap::IndexSet<T>, MIN_LEN, MAX_LEN>
+{
+    /// Removes a value from the set, returning whether the value was at the
+    /// set previously.
+    ///
+    /// # Errors
+    ///
+    /// Errors if the minimum confinement is not met after the removal.
+    pub fn remove(&mut self, elem: &T) -> Result<bool, Error> {
+        if !self.0.contains(elem) {
+            return Ok(false);
+        }
+        self.check_undersize()?;
+        Ok(self.0.shift_remove(elem))
+    }
+
+    /// Removes and returns the value in the set, if any, that is equal to the
+    /// given one.
+    ///
+    /// # Errors
+    ///
+    /// Errors if the minimum confinement is not met after the removal.
+    pub fn take(&mut self, elem: &T) -> Result<Option<T>, Error> {
+        if !self.0.contains(elem) {
+            return Ok(None);
+        }
+        self.check_undersize()?;
+        Ok(self.0.shift_take(elem))
+    }
+}
+
+#[cfg(feature = "indexmap")]
 impl<K: Eq + Hash, V, const MIN_LEN: usize, const MAX_LEN: usize>
     Confined<indexmap::IndexMap<K, V>, MIN_LEN, MAX_LEN>
 {
@@ -1700,13 +1650,10 @@ impl<K: Eq + Hash, V, const MIN_LEN: usize, const MAX_LEN: usize>
     ///
     /// Errors if the minimum confinement is not met after the removal.
     pub fn remove(&mut self, key: &K) -> Result<Option<V>, Error> {
-        let len = self.0.len();
-        if len == MIN_LEN || len - 1 < MIN_LEN {
-            return Err(Error::Undersize {
-                len: len - 1,
-                min_len: MIN_LEN,
-            });
+        if !self.0.contains_key(key) {
+            return Ok(None);
         }
+        self.check_undersize()?;
         Ok(self.0.shift_remove(key))
     }
 
@@ -2481,10 +2428,48 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "Undersize")]
     fn cant_go_below_min() {
+        let mut s = TinyString::new();
+        assert!(matches!(
+            s.remove(0),
+            Err(Error::Undersize { len: 0, min_len: 0 })
+        ));
+
+        let mut s = TinyVec::<u8>::new();
+        assert!(matches!(
+            s.remove(0),
+            Err(Error::Undersize { len: 0, min_len: 0 })
+        ));
+
+        let mut s = TinyOrdSet::<u8>::new();
+        assert!(matches!(s.remove(&0), Ok(false)));
+
+        let mut s = TinyOrdMap::<u8, u8>::new();
+        assert!(matches!(s.remove(&0), Ok(None)));
+
         let mut s = NonEmptyString::<U8>::with('a');
-        s.remove(0).unwrap();
+        assert!(matches!(
+            s.remove(0),
+            Err(Error::Undersize { len: 0, min_len: 1 })
+        ));
+
+        let mut v = NonEmptyVec::<u8>::with(1);
+        assert!(matches!(
+            v.remove(0),
+            Err(Error::Undersize { len: 0, min_len: 1 })
+        ));
+
+        let mut set = NonEmptyOrdSet::<u8>::with(1);
+        assert!(matches!(
+            set.remove(&1),
+            Err(Error::Undersize { len: 0, min_len: 1 })
+        ));
+
+        let mut map = NonEmptyOrdMap::<u8, u8>::with_key_value(1, 1);
+        assert!(matches!(
+            map.remove(&1),
+            Err(Error::Undersize { len: 0, min_len: 1 })
+        ));
     }
 
     #[test]

--- a/src/collection/confinement.rs
+++ b/src/collection/confinement.rs
@@ -19,9 +19,7 @@ use core::borrow::{Borrow, BorrowMut};
 use core::fmt::{self, Display, Formatter, LowerHex, UpperHex};
 use core::str::FromStr;
 use core::hash::Hash;
-use core::ops::{
-    Deref, Index, IndexMut, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
-};
+use core::ops::{Deref, Index, IndexMut};
 use alloc::vec::Vec;
 use alloc::string::String;
 use alloc::borrow::ToOwned;
@@ -42,7 +40,7 @@ use ascii::{AsAsciiStrError, AsciiChar, AsciiString};
 
 use crate::num::u24;
 
-/// Trait implemented by a collection types which need to support collection
+/// Trait implemented by collection types which need to support collection
 /// confinement.
 pub trait Collection: FromIterator<Self::Item> + Extend<Self::Item> {
     /// Item type contained within the collection.
@@ -717,156 +715,26 @@ where
     }
 }
 
-impl<C: Collection, const MIN_LEN: usize, const MAX_LEN: usize> Index<usize>
+impl<C: Collection, I, const MIN_LEN: usize, const MAX_LEN: usize> Index<I>
     for Confined<C, MIN_LEN, MAX_LEN>
 where
-    C: Index<usize, Output = C::Item>,
+    C: Index<I>,
 {
-    type Output = C::Item;
+    type Output = C::Output;
 
-    fn index(&self, index: usize) -> &Self::Output {
+    #[inline]
+    fn index(&self, index: I) -> &Self::Output {
         self.0.index(index)
     }
 }
 
-impl<C: Collection, const MIN_LEN: usize, const MAX_LEN: usize> IndexMut<usize>
+impl<C: Collection, I, const MIN_LEN: usize, const MAX_LEN: usize> IndexMut<I>
     for Confined<C, MIN_LEN, MAX_LEN>
 where
-    C: IndexMut<usize, Output = C::Item>,
+    C: IndexMut<I>,
 {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        self.0.index_mut(index)
-    }
-}
-
-impl<C: Collection, const MIN_LEN: usize, const MAX_LEN: usize> Index<Range<usize>>
-    for Confined<C, MIN_LEN, MAX_LEN>
-where
-    C: Index<Range<usize>, Output = [C::Item]>,
-{
-    type Output = [C::Item];
-
-    fn index(&self, index: Range<usize>) -> &Self::Output {
-        self.0.index(index)
-    }
-}
-
-impl<C: Collection, const MIN_LEN: usize, const MAX_LEN: usize> IndexMut<Range<usize>>
-    for Confined<C, MIN_LEN, MAX_LEN>
-where
-    C: IndexMut<Range<usize>, Output = [C::Item]>,
-{
-    fn index_mut(&mut self, index: Range<usize>) -> &mut Self::Output {
-        self.0.index_mut(index)
-    }
-}
-
-impl<C: Collection, const MIN_LEN: usize, const MAX_LEN: usize> Index<RangeTo<usize>>
-    for Confined<C, MIN_LEN, MAX_LEN>
-where
-    C: Index<RangeTo<usize>, Output = [C::Item]>,
-{
-    type Output = [C::Item];
-
-    fn index(&self, index: RangeTo<usize>) -> &Self::Output {
-        self.0.index(index)
-    }
-}
-
-impl<C: Collection, const MIN_LEN: usize, const MAX_LEN: usize> IndexMut<RangeTo<usize>>
-    for Confined<C, MIN_LEN, MAX_LEN>
-where
-    C: IndexMut<RangeTo<usize>, Output = [C::Item]>,
-{
-    fn index_mut(&mut self, index: RangeTo<usize>) -> &mut Self::Output {
-        self.0.index_mut(index)
-    }
-}
-
-impl<C: Collection, const MIN_LEN: usize, const MAX_LEN: usize> Index<RangeFrom<usize>>
-    for Confined<C, MIN_LEN, MAX_LEN>
-where
-    C: Index<RangeFrom<usize>, Output = [C::Item]>,
-{
-    type Output = [C::Item];
-
-    fn index(&self, index: RangeFrom<usize>) -> &Self::Output {
-        self.0.index(index)
-    }
-}
-
-impl<C: Collection, const MIN_LEN: usize, const MAX_LEN: usize> IndexMut<RangeFrom<usize>>
-    for Confined<C, MIN_LEN, MAX_LEN>
-where
-    C: IndexMut<RangeFrom<usize>, Output = [C::Item]>,
-{
-    fn index_mut(&mut self, index: RangeFrom<usize>) -> &mut Self::Output {
-        self.0.index_mut(index)
-    }
-}
-
-impl<C: Collection, const MIN_LEN: usize, const MAX_LEN: usize> Index<RangeInclusive<usize>>
-    for Confined<C, MIN_LEN, MAX_LEN>
-where
-    C: Index<RangeInclusive<usize>, Output = [C::Item]>,
-{
-    type Output = [C::Item];
-
-    fn index(&self, index: RangeInclusive<usize>) -> &Self::Output {
-        self.0.index(index)
-    }
-}
-
-impl<C: Collection, const MIN_LEN: usize, const MAX_LEN: usize> IndexMut<RangeInclusive<usize>>
-    for Confined<C, MIN_LEN, MAX_LEN>
-where
-    C: IndexMut<RangeInclusive<usize>, Output = [C::Item]>,
-{
-    fn index_mut(&mut self, index: RangeInclusive<usize>) -> &mut Self::Output {
-        self.0.index_mut(index)
-    }
-}
-
-impl<C: Collection, const MIN_LEN: usize, const MAX_LEN: usize> Index<RangeToInclusive<usize>>
-    for Confined<C, MIN_LEN, MAX_LEN>
-where
-    C: Index<RangeToInclusive<usize>, Output = [C::Item]>,
-{
-    type Output = [C::Item];
-
-    fn index(&self, index: RangeToInclusive<usize>) -> &Self::Output {
-        self.0.index(index)
-    }
-}
-
-impl<C: Collection, const MIN_LEN: usize, const MAX_LEN: usize> IndexMut<RangeToInclusive<usize>>
-    for Confined<C, MIN_LEN, MAX_LEN>
-where
-    C: IndexMut<RangeToInclusive<usize>, Output = [C::Item]>,
-{
-    fn index_mut(&mut self, index: RangeToInclusive<usize>) -> &mut Self::Output {
-        self.0.index_mut(index)
-    }
-}
-
-impl<C: Collection, const MIN_LEN: usize, const MAX_LEN: usize> Index<RangeFull>
-    for Confined<C, MIN_LEN, MAX_LEN>
-where
-    C: Index<RangeFull, Output = [C::Item]>,
-{
-    type Output = [C::Item];
-
-    fn index(&self, index: RangeFull) -> &Self::Output {
-        self.0.index(index)
-    }
-}
-
-impl<C: Collection, const MIN_LEN: usize, const MAX_LEN: usize> IndexMut<RangeFull>
-    for Confined<C, MIN_LEN, MAX_LEN>
-where
-    C: IndexMut<RangeFull, Output = [C::Item]>,
-{
-    fn index_mut(&mut self, index: RangeFull) -> &mut Self::Output {
+    #[inline]
+    fn index_mut(&mut self, index: I) -> &mut Self::Output {
         self.0.index_mut(index)
     }
 }
@@ -2638,5 +2506,24 @@ mod test {
         let coll = NonEmptyDeque::<u8, U8>::try_from_iter([1, 2, 3]).unwrap();
         assert_eq!(*coll.first(), 1);
         assert_eq!(*coll.last(), 3);
+    }
+
+    #[test]
+    fn test_index() {
+        let mut v = TinyVec::<u8>::new();
+        v.push(1u8).unwrap();
+        v.push(2u8).unwrap();
+        assert_eq!(v[0], 1);
+        assert_eq!(v[1], 2);
+        v[0] = 3;
+        assert_eq!(v[0], 3);
+        assert_eq!(&v[0..1], &[3]);
+
+        let mut m = TinyOrdMap::<u8, u8>::new();
+        m.insert(1u8, 10u8).unwrap();
+        m.insert(2u8, 20u8).unwrap();
+        assert_eq!(m[&1], 10);
+        assert_eq!(m[&2], 20);
+        // m[&1] = 11; // BTreeMap doesn't support IndexMut
     }
 }

--- a/src/collection/confinement.rs
+++ b/src/collection/confinement.rs
@@ -2528,13 +2528,13 @@ mod test {
         let mut s = TinyString::new();
         assert!(matches!(
             s.remove(0),
-            Err(Error::Undersize { len: 0, min_len: 0 })
+            Err(Error::OutOfBoundary { index: 0, len: 0 })
         ));
 
         let mut s = TinyVec::<u8>::new();
         assert!(matches!(
             s.remove(0),
-            Err(Error::Undersize { len: 0, min_len: 0 })
+            Err(Error::OutOfBoundary { index: 0, len: 0 })
         ));
 
         let mut s = TinyOrdSet::<u8>::new();
@@ -2548,11 +2548,19 @@ mod test {
             s.remove(0),
             Err(Error::Undersize { len: 1, min_len: 1 })
         ));
+        assert!(matches!(
+            s.remove(1),
+            Err(Error::OutOfBoundary { index: 1, len: 1 })
+        ));
 
         let mut v = NonEmptyVec::<u8>::with(1);
         assert!(matches!(
             v.remove(0),
             Err(Error::Undersize { len: 1, min_len: 1 })
+        ));
+        assert!(matches!(
+            v.remove(1),
+            Err(Error::OutOfBoundary { index: 1, len: 1 })
         ));
 
         let mut set = NonEmptyOrdSet::<u8>::with(1);

--- a/src/collection/confinement.rs
+++ b/src/collection/confinement.rs
@@ -33,9 +33,9 @@ use std::{
     io,
 };
 #[cfg(feature = "indexmap")]
-pub use indexmap_crate as indexmap;
+pub use indexmap;
 #[cfg(feature = "smallvec")]
-pub use smallvec_crate as smallvec;
+pub use smallvec;
 use amplify_num::hex;
 use amplify_num::hex::{FromHex, ToHex};
 use ascii::{AsAsciiStrError, AsciiChar, AsciiString};
@@ -614,7 +614,7 @@ pub const U64: usize = u64::MAX as usize;
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
-    serde(crate = "serde_crate")
+    serde(crate = "serde")
 )]
 pub struct Confined<C: Collection, const MIN_LEN: usize, const MAX_LEN: usize>(C);
 

--- a/src/collection/confinement.rs
+++ b/src/collection/confinement.rs
@@ -1064,8 +1064,8 @@ impl<C: KeyedCollection, const MIN_LEN: usize, const MAX_LEN: usize> Confined<C,
     }
 
     /// Inserts a new value into the confined collection under a given key.
-    /// Fails if the collection already contains the maximum number of elements
-    /// allowed by the confinement.
+    /// Fails when inserting a new key would exceed MAX_LEN.
+    /// Replacing an existing key's value always succeeds.
     pub fn insert(&mut self, key: C::Key, value: C::Value) -> Result<Option<C::Value>, Error> {
         if !self.0.contains_key(&key) {
             self.check_oversize()?;
@@ -2491,13 +2491,8 @@ mod test {
         for i in 1..=255 {
             map.insert(i, i).unwrap();
         }
-        assert!(matches!(
-            map.insert(255, 0),
-            Err(Error::Oversize {
-                len: 255,
-                max_len: 255
-            })
-        ));
+        // Replacing an existing key should succeed
+        assert_eq!(map.insert(255, 0), Ok(Some(255)));
         assert!(matches!(
             map.insert(0, 0),
             Err(Error::Oversize {

--- a/src/collection/confinement.rs
+++ b/src/collection/confinement.rs
@@ -1021,11 +1021,8 @@ where
     }
 }
 
-impl<C: Collection, const MIN_LEN: usize> Confined<C, MIN_LEN, U8>
-where
-    C: Default,
-{
-    /// Returns number of elements in the confined collection as `u8`. The
+impl<C: Collection, const MIN_LEN: usize> Confined<C, MIN_LEN, U8> {
+    /// Returns the number of elements in the confined collection as `u8`. The
     /// confinement guarantees that the collection length can't exceed
     /// `u8::MAX`.
     pub fn len_u8(&self) -> u8 {
@@ -1033,11 +1030,8 @@ where
     }
 }
 
-impl<C: Collection, const MIN_LEN: usize> Confined<C, MIN_LEN, U16>
-where
-    C: Default,
-{
-    /// Returns number of elements in the confined collection as `u16`. The
+impl<C: Collection, const MIN_LEN: usize> Confined<C, MIN_LEN, U16> {
+    /// Returns the number of elements in the confined collection as `u16`. The
     /// confinement guarantees that the collection length can't exceed
     /// `u16::MAX`.
     pub fn len_u16(&self) -> u16 {
@@ -1045,11 +1039,8 @@ where
     }
 }
 
-impl<C: Collection, const MIN_LEN: usize> Confined<C, MIN_LEN, U24>
-where
-    C: Default,
-{
-    /// Returns number of elements in the confined collection as `u24`. The
+impl<C: Collection, const MIN_LEN: usize> Confined<C, MIN_LEN, U24> {
+    /// Returns the number of elements in the confined collection as `u24`. The
     /// confinement guarantees that the collection length can't exceed
     /// `u24::MAX`.
     pub fn len_u24(&self) -> u24 {
@@ -1057,11 +1048,8 @@ where
     }
 }
 
-impl<C: Collection, const MIN_LEN: usize> Confined<C, MIN_LEN, U32>
-where
-    C: Default,
-{
-    /// Returns number of elements in the confined collection as `u32`. The
+impl<C: Collection, const MIN_LEN: usize> Confined<C, MIN_LEN, U32> {
+    /// Returns the number of elements in the confined collection as `u32`. The
     /// confinement guarantees that the collection length can't exceed
     /// `u32::MAX`.
     pub fn len_u32(&self) -> u32 {
@@ -1076,7 +1064,7 @@ impl<C: KeyedCollection, const MIN_LEN: usize, const MAX_LEN: usize> Confined<C,
     }
 
     /// Inserts a new value into the confined collection under a given key.
-    /// Fails if the collection already contains maximum number of elements
+    /// Fails if the collection already contains the maximum number of elements
     /// allowed by the confinement.
     pub fn insert(&mut self, key: C::Key, value: C::Value) -> Result<Option<C::Value>, Error> {
         self.check_oversize()?;

--- a/src/collection/confinement.rs
+++ b/src/collection/confinement.rs
@@ -1064,8 +1064,14 @@ impl<C: KeyedCollection, const MIN_LEN: usize, const MAX_LEN: usize> Confined<C,
     }
 
     /// Inserts a new value into the confined collection under a given key.
-    /// Fails when inserting a new key would exceed MAX_LEN.
-    /// Replacing an existing key's value always succeeds.
+    ///
+    /// If the key is already present, the value is overwritten and the previous
+    /// value is returned. This succeeds even when the collection is at capacity.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Oversize`] when the key is not already present and the
+    /// collection has reached `MAX_LEN`.
     pub fn insert(&mut self, key: C::Key, value: C::Value) -> Result<Option<C::Value>, Error> {
         if !self.0.contains_key(&key) {
             self.check_oversize()?;

--- a/src/collection/confinement.rs
+++ b/src/collection/confinement.rs
@@ -1168,6 +1168,12 @@ impl<const MIN_LEN: usize, const MAX_LEN: usize> Confined<String, MIN_LEN, MAX_L
     /// otherwise.
     pub fn remove(&mut self, index: usize) -> Result<char, Error> {
         self.check_boundary(index)?;
+        if !self.0.is_char_boundary(index) {
+            return Err(Error::OutOfBoundary {
+                index,
+                len: self.len(),
+            });
+        }
         self.check_undersize()?;
         Ok(self.0.remove(index))
     }

--- a/src/collection/confinement.rs
+++ b/src/collection/confinement.rs
@@ -933,6 +933,14 @@ impl<C: Collection, const MIN_LEN: usize, const MAX_LEN: usize> Confined<C, MIN_
         Ok(())
     }
 
+    fn check_boundary(&self, index: usize) -> Result<(), Error> {
+        let len = self.len();
+        if index >= len {
+            return Err(Error::OutOfBoundary { index, len });
+        }
+        Ok(())
+    }
+
     /// Constructs confinement over collection which was already size-checked.
     ///
     /// # Panics
@@ -1277,10 +1285,7 @@ impl<const MIN_LEN: usize, const MAX_LEN: usize> Confined<String, MIN_LEN, MAX_L
     /// otherwise.
     pub fn remove(&mut self, index: usize) -> Result<char, Error> {
         self.check_undersize()?;
-        let len = self.len();
-        if index >= len {
-            return Err(Error::OutOfBoundary { index, len });
-        }
+        self.check_boundary(index)?;
         Ok(self.0.remove(index))
     }
 }
@@ -1299,10 +1304,7 @@ impl<const MIN_LEN: usize, const MAX_LEN: usize> Confined<AsciiString, MIN_LEN, 
     /// otherwise.
     pub fn remove(&mut self, index: usize) -> Result<AsciiChar, Error> {
         self.check_undersize()?;
-        let len = self.len();
-        if index >= len {
-            return Err(Error::OutOfBoundary { index, len });
-        }
+        self.check_boundary(index)?;
         Ok(self.0.remove(index))
     }
 }
@@ -1379,10 +1381,7 @@ impl<T, const MIN_LEN: usize, const MAX_LEN: usize> Confined<Vec<T>, MIN_LEN, MA
     /// removed element otherwise.
     pub fn remove(&mut self, index: usize) -> Result<T, Error> {
         self.check_undersize()?;
-        let len = self.len();
-        if index >= len {
-            return Err(Error::OutOfBoundary { index, len });
-        }
+        self.check_boundary(index)?;
         Ok(self.0.remove(index))
     }
 
@@ -1436,10 +1435,7 @@ impl<T, const MIN_LEN: usize, const MAX_LEN: usize> Confined<VecDeque<T>, MIN_LE
     /// removed element otherwise.
     pub fn remove(&mut self, index: usize) -> Result<T, Error> {
         self.check_undersize()?;
-        let len = self.len();
-        if index >= len {
-            return Err(Error::OutOfBoundary { index, len });
-        }
+        self.check_boundary(index)?;
         Ok(self.0.remove(index).expect("element within the length"))
     }
 
@@ -2466,6 +2462,30 @@ mod test {
                 len: 256,
                 max_len: 255
             })
+        ));
+    }
+
+    #[test]
+    fn boundary() {
+        let mut s = TinyString::new();
+        s.push('a').unwrap();
+        assert!(matches!(
+            s.remove(1),
+            Err(Error::OutOfBoundary { index: 1, len: 1 })
+        ));
+
+        let mut v = TinyVec::<u8>::new();
+        v.push(1).unwrap();
+        assert!(matches!(
+            v.remove(1),
+            Err(Error::OutOfBoundary { index: 1, len: 1 })
+        ));
+
+        let mut d = TinyDeque::<u8>::new();
+        d.push_back(1).unwrap();
+        assert!(matches!(
+            d.remove(1),
+            Err(Error::OutOfBoundary { index: 1, len: 1 })
         ));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub use amplify_derive::{Wrapper, WrapperMut, Display, AsAny, From, Getters, Err
 
 #[cfg(feature = "serde")]
 #[macro_use]
-extern crate serde_crate as serde;
+pub extern crate serde;
 
 extern crate amplify_num;
 


### PR DESCRIPTION
- New `SmallVec` support in confined collections via `smallvec` feature
- New `IndexSet` and `IndexMap` support in confined collections via `indexmap` feature
- New non-failing `first` and `last` methods in confined non-empty collections


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Confined-collection support added for SmallVec, IndexSet, and IndexMap
  * Non-failing `first` and `last` for confined non-empty collections
  * Helper macros for constructing confined collections
  * New `CursorDeque` in IO

* **Chores**
  * Version bumped to 4.10.0
  * Added optional SmallVec and IndexMap dependencies and feature flags
  * `serde` feature adjusted to expose serde compatibility

* **Documentation**
  * CHANGELOG updated with 4.10.0 and historical entries
<!-- end of auto-generated comment: release notes by coderabbit.ai -->